### PR TITLE
fix: update LLMAAS_MODEL alias to qwen3:235b

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ S3_REGION_NAME=fr1
 # API OpenAI-compatible. L'URL INCLUT déjà /v1 — ne PAS l'ajouter dans le code.
 LLMAAS_API_URL=https://api.ai.cloud-temple.com/v1
 LLMAAS_API_KEY=your_llmaas_key
-LLMAAS_MODEL=qwen3-2507:235b
+LLMAAS_MODEL=qwen3:235b
 LLMAAS_MAX_TOKENS=100000
 LLMAAS_TEMPERATURE=0.3
 


### PR DESCRIPTION
Fixes invalid model alias in .env.example which caused consolidation tests to fail.