### PR TITLE
fix(cli): improve error unwrapping and accept degraded health status

### DIFF
--- a/scripts/cli/client.py
+++ b/scripts/cli/client.py
@@ -105,10 +105,16 @@ class MCPClient:
 
                     return {"status": "ok", "raw": ""}
 
-        except Exception as e:
+        except BaseException as e:
+            # Unwrap ExceptionGroup / TaskGroup to surface the real error.
+            # The MCP SDK uses anyio TaskGroups; on auth failure (401) the
+            # actual HTTP error is buried inside an ExceptionGroup.
+            cause = e
+            while isinstance(cause, BaseExceptionGroup) and cause.exceptions:
+                cause = cause.exceptions[0]
             return {
                 "status": "error",
-                "message": f"Erreur MCP : {e}",
+                "message": f"Erreur MCP : {cause}",
             }
 
     async def list_tools(self) -> list:

--- a/scripts/cli/commands.py
+++ b/scripts/cli/commands.py
@@ -39,7 +39,7 @@ def _run_tool(ctx, tool_name, args, on_success, json_flag=False):
             result = await client.call_tool(tool_name, args)
             if json_flag:
                 show_json(result)
-            elif result.get("status") in ("ok", "healthy", "created", "deleted", "connected", "disconnected"):
+            elif result.get("status") in ("ok", "healthy", "degraded", "created", "deleted", "connected", "disconnected"):
                 on_success(result)
             else:
                 show_error(result.get("message", f"Erreur: {result.get('status', '?')}"))


### PR DESCRIPTION
## Summary

- **Unwrap ExceptionGroup/TaskGroup errors** in `MCPClient.call_tool` to surface the real underlying error (e.g. HTTP 401) instead of showing the opaque `ExceptionGroup` wrapper. The MCP SDK uses anyio TaskGroups, which wrap failures in `BaseExceptionGroup`.
- **Add `degraded` to accepted health-check statuses** in the CLI so that partial-health responses are displayed correctly instead of being treated as errors.

## Test plan

- [x] Trigger an MCP auth failure (e.g. invalid token) and verify the CLI now shows the actual HTTP error message
- [x] Run `health` command against a server returning `degraded` status and verify it displays normally