### PR TITLE
feat: production middleware stack, observability, and hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,43 @@
 # =============================================================================
-# Dockerfile — Live Memory MCP Server (rootless)
+# Dockerfile — Live Memory MCP Server (multi-stage, rootless)
 # =============================================================================
-# Image Python 3.11 slim avec le serveur MCP Live Memory.
-# Le conteneur tourne en utilisateur non-root (mcp, UID 10001).
-# Aucune opération root après le USER — 100% rootless.
+# Two-stage build:
+#   1. Builder — installs dependencies into a virtual environment
+#   2. Runtime — copies only the venv + source code (no pip, no build tools)
+#
+# Result: smaller image, no build tools in prod, reduced attack surface.
 #
 # Usage :
 #   docker compose build
 #   docker compose up -d
 # =============================================================================
 
-FROM python:3.11-slim
+ARG PYTHON_VER=3.11
+
+# ─────────────────────────────────────────────────────────────
+# Stage 1: Builder — install dependencies
+# ─────────────────────────────────────────────────────────────
+FROM python:${PYTHON_VER}-slim AS builder
+
+WORKDIR /build
+
+COPY requirements.txt .
+
+RUN python -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir -r requirements.txt
+
+# ─────────────────────────────────────────────────────────────
+# Stage 2: Runtime — lean production image
+# ─────────────────────────────────────────────────────────────
+FROM python:${PYTHON_VER}-slim
 
 WORKDIR /app
 
 # Créer l'utilisateur non-root AVANT tout COPY
 RUN useradd -r -u 10001 -s /bin/false mcp
 
-# Dépendances Python (en premier pour profiter du cache Docker)
-COPY --chown=mcp:mcp requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Copy virtual environment from builder (no pip/setuptools in runtime)
+COPY --from=builder --chown=mcp:mcp /opt/venv /opt/venv
 
 # Code source — copié directement avec les bons droits
 COPY --chown=mcp:mcp src/ src/
@@ -27,8 +45,11 @@ COPY --chown=mcp:mcp scripts/ scripts/
 COPY --chown=mcp:mcp RULES/ RULES/
 COPY --chown=mcp:mcp VERSION .
 
-# Le module live_mem est dans src/ → ajouter au PYTHONPATH
-ENV PYTHONPATH=/app/src
+# Use the venv Python and add src/ to module path
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONPATH=/app/src \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
 # Basculer sur l'utilisateur non-root (rootless)
 USER mcp

--- a/src/live_mem/auth/middleware.py
+++ b/src/live_mem/auth/middleware.py
@@ -21,6 +21,7 @@ import logging
 from typing import Optional
 from .context import current_token_info, check_access
 from ..config import get_settings
+from ..middleware import current_request_id
 
 logger = logging.getLogger("live_mem.auth")
 
@@ -35,7 +36,7 @@ class AuthMiddleware:
     """
 
     # Routes qui ne nécessitent pas d'authentification
-    PUBLIC_PATHS = {"/health", "/favicon.ico", "/live", "/live/"}
+    PUBLIC_PATHS = {"/health", "/metrics", "/favicon.ico", "/live", "/live/"}
 
     # Préfixes de routes publiques (fichiers statiques)
     PUBLIC_PREFIXES = ("/static/",)
@@ -143,8 +144,12 @@ class LoggingMiddleware:
     """
     Middleware ASGI de logging des requêtes HTTP.
 
-    Log sur stderr : méthode, path, status, durée.
+    Emits structured JSON log lines to stderr with:
+    request_id, method, path, status, latency_ms, client identity.
     """
+
+    # Paths not worth logging (high-frequency probes)
+    _QUIET_PATHS = {"/health", "/metrics"}
 
     def __init__(self, app):
         self.app = app
@@ -168,9 +173,22 @@ class LoggingMiddleware:
             await self.app(scope, receive, send_wrapper)
         finally:
             elapsed = round((time.monotonic() - t0) * 1000, 1)
-            # Ne pas logger les health checks pour éviter le bruit
-            if path not in ("/health",):
-                logger.info("%s %s → %s (%.0fms)", method, path, status_code, elapsed)
+            # Skip health/metrics probes to reduce noise
+            if path not in self._QUIET_PATHS:
+                token_info = current_token_info.get()
+                entry = {
+                    "request_id": current_request_id.get(),
+                    "method": method,
+                    "path": path,
+                    "status": status_code,
+                    "latency_ms": elapsed,
+                }
+                if token_info:
+                    entry["client"] = token_info.get("client_name", "anonymous")
+                client = scope.get("client")
+                if client:
+                    entry["client_ip"] = client[0]
+                logger.info(json.dumps(entry, ensure_ascii=False))
 
 
 class StaticFilesMiddleware:
@@ -260,22 +278,45 @@ class StaticFilesMiddleware:
     # ─────────────────── Health Check ───────────────────
 
     async def _handle_health(self, send):
-        """Endpoint /health — réponse JSON simple pour les healthchecks."""
+        """
+        Endpoint /health — probes S3 connectivity.
+
+        Returns 200 + {"status": "healthy"} when S3 is reachable,
+        or 503 + {"status": "unhealthy", "reason": "..."} otherwise.
+        Keeps the probe fast (2s timeout on S3 test).
+        """
         import json
         from pathlib import Path
 
         version_file = Path(__file__).parent.parent.parent.parent / "VERSION"
         version = version_file.read_text().strip() if version_file.exists() else "dev"
 
-        body = json.dumps({
+        status_code = 200
+        result = {
             "status": "healthy",
             "service": "live-memory",
             "version": version,
             "transport": "streamable-http",
-        }).encode("utf-8")
+        }
+
+        # Probe S3 connectivity (the critical dependency)
+        try:
+            from ..core.storage import get_storage
+            storage = get_storage()
+            s3_result = await storage.test_connection()
+            if s3_result.get("status") != "ok":
+                status_code = 503
+                result["status"] = "unhealthy"
+                result["reason"] = f"S3: {s3_result.get('message', 'not reachable')}"
+        except Exception as e:
+            status_code = 503
+            result["status"] = "unhealthy"
+            result["reason"] = f"S3: {e}"
+
+        body = json.dumps(result).encode("utf-8")
         await send({
             "type": "http.response.start",
-            "status": 200,
+            "status": status_code,
             "headers": [
                 (b"content-type", b"application/json; charset=utf-8"),
                 (b"content-length", str(len(body)).encode()),

--- a/src/live_mem/config.py
+++ b/src/live_mem/config.py
@@ -12,12 +12,22 @@ Usage :
     print(settings.s3_bucket_name)
 """
 
+import logging
 from functools import lru_cache
+from typing import Optional
+
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
+
+_logger = logging.getLogger("live_mem.config")
 
 
 class Settings(BaseSettings):
-    """Configuration chargée depuis les variables d'env / .env."""
+    """
+    Configuration chargée depuis les variables d'env / .env.
+
+    Includes startup validation that fails fast on misconfiguration.
+    """
 
     # ─── Serveur MCP ───────────────────────────────────────────
     mcp_server_name: str = "Live Memory"
@@ -59,9 +69,87 @@ class Settings(BaseSettings):
     consolidation_max_notes: int = 500      # Max notes traitées par consolidation
     consolidation_batch_size: int = 5       # Notes par lot LLM (réponses courtes = moins de drift)
 
+    # ─── Response limits ──────────────────────────────────────
+    response_max_bytes: int = 512 * 1024    # Max response body size (512 KB)
+
     # extra="ignore" permet d'avoir des variables dans .env (SITE_ADDRESS, WAF_PORT)
     # qui ne sont pas déclarées dans Settings (utilisées par Docker/Caddy uniquement)
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
+
+    @model_validator(mode="after")
+    def _validate_config(self) -> "Settings":
+        """Semantic validation — fail fast at startup on misconfiguration."""
+        errors: list[str] = []
+
+        # Port range
+        if not (1 <= self.mcp_server_port <= 65535):
+            errors.append(
+                f"MCP_SERVER_PORT={self.mcp_server_port} out of range [1, 65535]"
+            )
+
+        # S3: all-or-nothing (all three must be set, or none)
+        s3_fields = [self.s3_endpoint_url, self.s3_access_key_id, self.s3_secret_access_key]
+        s3_set = [bool(f) for f in s3_fields]
+        if any(s3_set) and not all(s3_set):
+            errors.append(
+                "S3 partially configured — set all of S3_ENDPOINT_URL, "
+                "S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY or none"
+            )
+
+        # S3 endpoint URL format
+        if self.s3_endpoint_url and not self.s3_endpoint_url.startswith(("http://", "https://")):
+            errors.append(
+                f"S3_ENDPOINT_URL must start with http:// or https://, "
+                f"got '{self.s3_endpoint_url[:50]}'"
+            )
+
+        # Bucket name: S3 naming rules (3-63 chars, lowercase, no underscore)
+        if self.s3_bucket_name:
+            import re
+            if not re.match(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", self.s3_bucket_name):
+                _logger.warning(
+                    "S3_BUCKET_NAME='%s' may not be a valid S3 bucket name",
+                    self.s3_bucket_name,
+                )
+
+        # LLM: API key without URL or vice versa
+        if bool(self.llmaas_api_url) != bool(self.llmaas_api_key):
+            errors.append(
+                "LLMaaS partially configured — set both LLMAAS_API_URL "
+                "and LLMAAS_API_KEY or neither"
+            )
+
+        # Consolidation ranges
+        if self.consolidation_timeout < 10:
+            errors.append(
+                f"CONSOLIDATION_TIMEOUT={self.consolidation_timeout} too low (min 10s)"
+            )
+        if self.consolidation_max_notes < 1:
+            errors.append(
+                f"CONSOLIDATION_MAX_NOTES={self.consolidation_max_notes} must be ≥1"
+            )
+        if self.consolidation_batch_size < 1:
+            errors.append(
+                f"CONSOLIDATION_BATCH_SIZE={self.consolidation_batch_size} must be ≥1"
+            )
+
+        # Temperature range
+        if not (0.0 <= self.llmaas_temperature <= 2.0):
+            errors.append(
+                f"LLMAAS_TEMPERATURE={self.llmaas_temperature} out of range [0.0, 2.0]"
+            )
+
+        # Response limit
+        if self.response_max_bytes < 1024:
+            errors.append(
+                f"RESPONSE_MAX_BYTES={self.response_max_bytes} too low (min 1024)"
+            )
+
+        if errors:
+            msg = "Configuration errors at startup:\n  - " + "\n  - ".join(errors)
+            raise ValueError(msg)
+
+        return self
 
 
 @lru_cache()

--- a/src/live_mem/middleware.py
+++ b/src/live_mem/middleware.py
@@ -1,0 +1,374 @@
+# -*- coding: utf-8 -*-
+"""
+Production middleware stack for Live Memory MCP Server.
+
+ASGI middlewares for observability, safety, and audit:
+    - RequestIdMiddleware     — unique correlation ID per request (contextvars)
+    - MetricsMiddleware       — per-path request counts, error rates, latency
+    - ResponseLimitMiddleware — truncates oversized responses (default 512 KB)
+    - AuditMiddleware         — structured audit trail (who, what, when)
+
+These are layered on top of the existing auth/logging/static middleware.
+"""
+
+import json
+import time
+import uuid
+import logging
+from collections import defaultdict
+from contextvars import ContextVar
+from typing import Optional
+
+from .auth.context import current_token_info
+
+# ─────────────────────────────────────────────────────────────
+# Shared context: request ID accessible from any async context
+# ─────────────────────────────────────────────────────────────
+current_request_id: ContextVar[str] = ContextVar("current_request_id", default="-")
+
+logger = logging.getLogger("live_mem.middleware")
+audit_logger = logging.getLogger("live_mem.audit")
+
+
+# =============================================================================
+# RequestIdMiddleware
+# =============================================================================
+
+class RequestIdMiddleware:
+    """
+    Generates a unique request ID (UUID4 short) for every HTTP request
+    and stores it in a ContextVar for downstream correlation.
+
+    The ID is also injected as an ``X-Request-Id`` response header so
+    clients can reference it in bug reports.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        request_id = uuid.uuid4().hex[:12]
+        tok = current_request_id.set(request_id)
+
+        async def send_with_id(message):
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                headers.append((b"x-request-id", request_id.encode()))
+                message = {**message, "headers": headers}
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_id)
+        finally:
+            current_request_id.reset(tok)
+
+
+# =============================================================================
+# MetricsMiddleware
+# =============================================================================
+
+class MetricsMiddleware:
+    """
+    Tracks per-path request counts, error counts, and cumulative latency.
+
+    Exposes ``/metrics`` endpoint in Prometheus exposition format (default)
+    or JSON (``Accept: application/json``).
+    """
+
+    def __init__(self, app):
+        self.app = app
+        self._start_time = time.monotonic()
+        # Counters: path -> count
+        self._request_count: dict[str, int] = defaultdict(int)
+        self._error_count: dict[str, int] = defaultdict(int)
+        # Latency: path -> cumulative ms
+        self._latency_ms: dict[str, float] = defaultdict(float)
+        # Status code distribution
+        self._status_codes: dict[int, int] = defaultdict(int)
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        path = scope.get("path", "")
+
+        # Serve metrics endpoint
+        if path == "/metrics":
+            return await self._serve_metrics(scope, send)
+
+        # Track the request
+        # Normalize MCP paths to a single bucket
+        bucket = "/mcp" if path.startswith("/mcp") else path
+        self._request_count[bucket] += 1
+
+        t0 = time.monotonic()
+        status_code = 0
+
+        async def send_wrapper(message):
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message.get("status", 0)
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            elapsed = (time.monotonic() - t0) * 1000
+            self._latency_ms[bucket] += elapsed
+            self._status_codes[status_code] += 1
+            if status_code >= 400:
+                self._error_count[bucket] += 1
+
+    async def _serve_metrics(self, scope, send):
+        """Serve /metrics in Prometheus or JSON format."""
+        headers = dict(scope.get("headers", []))
+        accept = headers.get(b"accept", b"").decode()
+        uptime = round(time.monotonic() - self._start_time, 1)
+
+        total_requests = sum(self._request_count.values())
+        total_errors = sum(self._error_count.values())
+
+        if "application/json" in accept:
+            data = {
+                "uptime_seconds": uptime,
+                "total_requests": total_requests,
+                "total_errors": total_errors,
+                "by_path": {
+                    path: {
+                        "requests": self._request_count[path],
+                        "errors": self._error_count[path],
+                        "latency_ms_total": round(self._latency_ms[path], 1),
+                        "latency_ms_avg": round(
+                            self._latency_ms[path] / self._request_count[path], 1
+                        ) if self._request_count[path] else 0,
+                    }
+                    for path in sorted(self._request_count)
+                },
+                "status_codes": dict(sorted(self._status_codes.items())),
+            }
+            body = json.dumps(data).encode()
+            ct = b"application/json"
+        else:
+            # Prometheus exposition format
+            lines = []
+            lines.append("# HELP livemem_uptime_seconds Server uptime in seconds")
+            lines.append("# TYPE livemem_uptime_seconds gauge")
+            lines.append(f"livemem_uptime_seconds {uptime}")
+            lines.append("")
+            lines.append("# HELP livemem_requests_total Total HTTP requests")
+            lines.append("# TYPE livemem_requests_total counter")
+            for path in sorted(self._request_count):
+                safe = path.replace('"', '\\"')
+                lines.append(
+                    f'livemem_requests_total{{path="{safe}"}} {self._request_count[path]}'
+                )
+            lines.append("")
+            lines.append("# HELP livemem_errors_total Total HTTP errors (4xx+5xx)")
+            lines.append("# TYPE livemem_errors_total counter")
+            for path in sorted(self._error_count):
+                safe = path.replace('"', '\\"')
+                lines.append(
+                    f'livemem_errors_total{{path="{safe}"}} {self._error_count[path]}'
+                )
+            lines.append("")
+            lines.append("# HELP livemem_latency_ms_total Cumulative latency in ms")
+            lines.append("# TYPE livemem_latency_ms_total counter")
+            for path in sorted(self._latency_ms):
+                safe = path.replace('"', '\\"')
+                lines.append(
+                    f'livemem_latency_ms_total{{path="{safe}"}} {round(self._latency_ms[path], 1)}'
+                )
+            lines.append("")
+            lines.append("# HELP livemem_http_status_total Responses by status code")
+            lines.append("# TYPE livemem_http_status_total counter")
+            for code in sorted(self._status_codes):
+                lines.append(
+                    f'livemem_http_status_total{{code="{code}"}} {self._status_codes[code]}'
+                )
+            lines.append("")
+            body = "\n".join(lines).encode()
+            ct = b"text/plain; version=0.0.4; charset=utf-8"
+
+        await send({
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [
+                (b"content-type", ct),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        })
+        await send({"type": "http.response.body", "body": body})
+
+
+# =============================================================================
+# ResponseLimitMiddleware
+# =============================================================================
+
+class ResponseLimitMiddleware:
+    """
+    Truncates HTTP response bodies that exceed ``max_bytes`` (default 512 KB).
+
+    Adds ``X-Response-Truncated: true`` header when truncation occurs.
+    Prevents oversized MCP tool responses from crashing clients.
+    """
+
+    def __init__(self, app, *, max_bytes: int = 512 * 1024):
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        body_parts: list[bytes] = []
+        total_size = 0
+        truncated = False
+        headers_sent = False
+
+        async def buffered_send(message):
+            nonlocal total_size, truncated, headers_sent
+
+            if message["type"] == "http.response.start":
+                # Store start message, we'll send it when we have the body
+                buffered_send._start_message = message
+                return
+
+            if message["type"] == "http.response.body":
+                chunk = message.get("body", b"")
+                more_body = message.get("more_body", False)
+
+                if not truncated:
+                    remaining = self.max_bytes - total_size
+                    if len(chunk) > remaining:
+                        chunk = chunk[:remaining]
+                        truncated = True
+                        more_body = False
+
+                    total_size += len(chunk)
+                    body_parts.append(chunk)
+
+                if not more_body or truncated:
+                    # Time to send everything
+                    full_body = b"".join(body_parts)
+
+                    start = buffered_send._start_message
+                    headers = list(start.get("headers", []))
+
+                    if truncated:
+                        # Replace the body with a JSON error instead of
+                        # returning an unreadable truncated payload.
+                        ct_values = [
+                            v.decode() for k, v in headers
+                            if k == b"content-type"
+                        ]
+                        is_json = any("json" in ct for ct in ct_values)
+
+                        if is_json:
+                            full_body = json.dumps({
+                                "_truncated": True,
+                                "_message": (
+                                    f"Response exceeded {self.max_bytes} bytes "
+                                    f"and was truncated. Use more specific "
+                                    f"queries to reduce response size."
+                                ),
+                            }).encode()
+
+                        headers.append((b"x-response-truncated", b"true"))
+                        logger.warning(
+                            "Response truncated: %s %s (%d bytes > %d limit)",
+                            scope.get("method", "?"),
+                            scope.get("path", "?"),
+                            total_size,
+                            self.max_bytes,
+                        )
+
+                    # Update content-length
+                    headers = [
+                        (k, v) for k, v in headers if k != b"content-length"
+                    ]
+                    headers.append(
+                        (b"content-length", str(len(full_body)).encode())
+                    )
+
+                    await send({**start, "headers": headers})
+                    await send({
+                        "type": "http.response.body",
+                        "body": full_body,
+                    })
+
+        buffered_send._start_message = None
+        await self.app(scope, receive, buffered_send)
+
+
+# =============================================================================
+# AuditMiddleware
+# =============================================================================
+
+class AuditMiddleware:
+    """
+    Emits structured audit log entries for MCP tool calls.
+
+    Logs to the ``live_mem.audit`` logger at INFO level as JSON lines.
+    Each entry includes: timestamp, request_id, client identity,
+    HTTP method, path, status code, and latency.
+
+    Only audits non-public, non-static paths (i.e., /mcp and /api).
+    """
+
+    # Paths that don't need auditing
+    _SKIP_PATHS = {"/health", "/metrics", "/favicon.ico", "/live", "/live/"}
+    _SKIP_PREFIXES = ("/static/",)
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        path = scope.get("path", "")
+
+        # Skip non-interesting paths
+        if path in self._SKIP_PATHS:
+            return await self.app(scope, receive, send)
+        if any(path.startswith(p) for p in self._SKIP_PREFIXES):
+            return await self.app(scope, receive, send)
+
+        method = scope.get("method", "?")
+        t0 = time.monotonic()
+        status_code = 0
+
+        async def send_wrapper(message):
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message.get("status", 0)
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            elapsed = round((time.monotonic() - t0) * 1000, 1)
+
+            # Build audit entry
+            token_info = current_token_info.get()
+            entry = {
+                "event": "request",
+                "request_id": current_request_id.get(),
+                "method": method,
+                "path": path,
+                "status": status_code,
+                "latency_ms": elapsed,
+                "client": token_info.get("client_name", "anonymous") if token_info else "unauthenticated",
+                "auth_type": token_info.get("type", "none") if token_info else "none",
+                "permissions": token_info.get("permissions", []) if token_info else [],
+            }
+
+            # Extract client IP
+            client = scope.get("client")
+            if client:
+                entry["client_ip"] = client[0]
+
+            audit_logger.info(json.dumps(entry, ensure_ascii=False))

--- a/src/live_mem/server.py
+++ b/src/live_mem/server.py
@@ -31,15 +31,30 @@ from mcp.server.fastmcp import FastMCP
 from .config import get_settings
 
 # ─────────────────────────────────────────────────────────────
-# Configuration du logging (stderr uniquement, jamais stdout)
-# Format : timestamp level [module] message
+# Configuration du logging (stderr uniquement, JSON structuré)
 # ─────────────────────────────────────────────────────────────
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-5s [%(name)s] %(message)s",
-    datefmt="%H:%M:%S",
-    stream=sys.stderr,
-)
+
+class _JsonFormatter(logging.Formatter):
+    """Structured JSON log formatter for production log aggregation."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        import json as _json
+        entry = {
+            "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        if record.exc_info and record.exc_info[0] is not None:
+            entry["exception"] = self.formatException(record.exc_info)
+        return _json.dumps(entry, ensure_ascii=False)
+
+
+_handler = logging.StreamHandler(sys.stderr)
+_handler.setFormatter(_JsonFormatter())
+logging.root.addHandler(_handler)
+logging.root.setLevel(logging.INFO)
+
 # Réduire le bruit des librairies tierces
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
@@ -82,20 +97,27 @@ def create_app():
     Crée l'application ASGI complète avec les middlewares.
 
     Pile d'exécution (premier exécuté → dernier) :
-        AuthMiddleware → LoggingMiddleware → StaticFilesMiddleware
-        → mcp.streamable_http_app()
+        RequestId → Metrics → Auth → Audit → Logging
+        → ResponseLimit → StaticFiles → MCP Streamable HTTP
 
+    Le RequestIdMiddleware génère un ID unique par requête (contextvars).
+    Le MetricsMiddleware expose /metrics et collecte les compteurs.
     L'AuthMiddleware extrait le Bearer token et l'injecte dans les contextvars.
-    Le LoggingMiddleware trace les requêtes HTTP sur stderr.
+    L'AuditMiddleware émet des entrées d'audit JSON structurées.
+    Le LoggingMiddleware trace les requêtes HTTP en JSON sur stderr.
+    Le ResponseLimitMiddleware tronque les réponses > 512 KB.
     Le StaticFilesMiddleware sert /live, /static/*, /api/* (interface web).
-
-    Note: HostNormalizerMiddleware supprimé — Streamable HTTP n'a pas
-    le problème de validation Host que SSE avait avec Starlette.
     """
     from .auth.middleware import (
         AuthMiddleware,
         LoggingMiddleware,
         StaticFilesMiddleware,
+    )
+    from .middleware import (
+        RequestIdMiddleware,
+        MetricsMiddleware,
+        ResponseLimitMiddleware,
+        AuditMiddleware,
     )
 
     # L'app de base est le Streamable HTTP handler du SDK MCP
@@ -103,10 +125,13 @@ def create_app():
     app = mcp.streamable_http_app()
 
     # Empiler les middlewares (dernier ajouté = premier exécuté)
-    # Flux requête : Auth → Logging → StaticFiles → MCP Streamable HTTP
     app = StaticFilesMiddleware(app)
+    app = ResponseLimitMiddleware(app, max_bytes=settings.response_max_bytes)
     app = LoggingMiddleware(app)
+    app = AuditMiddleware(app)
     app = AuthMiddleware(app)
+    app = MetricsMiddleware(app)
+    app = RequestIdMiddleware(app)
 
     return app
 

--- a/src/live_mem/tools/admin.py
+++ b/src/live_mem/tools/admin.py
@@ -20,6 +20,7 @@ Voir AUTH_AND_COLLABORATION.md pour le modèle de tokens.
 from typing import Annotated
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 
@@ -34,7 +35,7 @@ def register(mcp: FastMCP) -> int:
         Nombre d'outils enregistrés (7)
     """
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=False))
     async def admin_create_token(
         name: Annotated[str, Field(description="Nom descriptif du token (ex: 'agent-cline', 'ci-pipeline')")],
         permissions: Annotated[str, Field(description="Permissions : 'read', 'read,write' ou 'read,write,admin'")],
@@ -76,7 +77,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "admin")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def admin_list_tokens() -> dict:
         """
         Liste tous les tokens (métadonnées seulement, jamais en clair).
@@ -100,7 +101,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "admin")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))
     async def admin_revoke_token(
         token_hash: Annotated[str, Field(description="Hash tronqué du token à révoquer (obtenu via admin_list_tokens)")],
     ) -> dict:
@@ -126,7 +127,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "admin")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
     async def admin_delete_token(
         token_hash: Annotated[str, Field(description="Hash tronqué du token à supprimer (obtenu via admin_list_tokens)")],
     ) -> dict:
@@ -159,7 +160,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "admin")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
     async def admin_purge_tokens(
         revoked_only: Annotated[bool, Field(default=True, description="True = supprime uniquement les tokens révoqués, False = supprime TOUS les tokens")] = True,
     ) -> dict:
@@ -190,7 +191,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "admin")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True))
     async def admin_update_token(
         token_hash: Annotated[str, Field(description="Hash tronqué du token à modifier (obtenu via admin_list_tokens)")],
         space_ids: Annotated[str, Field(default="", description="Nouveaux espaces autorisés séparés par virgules (vide = pas de changement)")] = "",
@@ -226,7 +227,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "admin")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))
     async def admin_gc_notes(
         space_id: Annotated[str, Field(default="", description="Espace cible (vide = scanner TOUS les espaces)")] = "",
         max_age_days: Annotated[int, Field(default=7, description="Seuil d'âge en jours pour considérer une note comme orpheline (défaut 7)")] = 7,

--- a/src/live_mem/tools/backup.py
+++ b/src/live_mem/tools/backup.py
@@ -18,6 +18,7 @@ Voir S3_DATA_MODEL.md pour l'arborescence.
 from typing import Annotated
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 
@@ -32,7 +33,7 @@ def register(mcp: FastMCP) -> int:
         Nombre d'outils enregistrés (5)
     """
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=False))
     async def backup_create(
         space_id: Annotated[str, Field(description="Identifiant de l'espace à sauvegarder")],
         description: Annotated[str, Field(default="", description="Description du backup (optionnel, ex: 'avant migration')")] = "",
@@ -67,7 +68,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "backup")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def backup_list(
         space_id: Annotated[str, Field(default="", description="Filtrer par espace (vide = tous les espaces accessibles)")] = "",
     ) -> dict:
@@ -117,7 +118,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "backup")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=False))
     async def backup_restore(
         backup_id: Annotated[str, Field(description="Identifiant du backup au format 'space_id/timestamp'")],
         confirm: Annotated[bool, Field(default=False, description="Doit être True pour confirmer la restauration (sécurité)")] = False,
@@ -154,7 +155,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "backup")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def backup_download(
         backup_id: Annotated[str, Field(description="Identifiant du backup au format 'space_id/timestamp'")],
     ) -> dict:
@@ -186,7 +187,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "backup")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
     async def backup_delete(
         backup_id: Annotated[str, Field(description="Identifiant du backup au format 'space_id/timestamp'")],
         confirm: Annotated[bool, Field(default=False, description="Doit être True pour confirmer la suppression (sécurité, irréversible)")] = False,

--- a/src/live_mem/tools/bank.py
+++ b/src/live_mem/tools/bank.py
@@ -24,6 +24,7 @@ Voir CONSOLIDATION_LLM.md pour le pipeline détaillé.
 from typing import Annotated
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 
@@ -38,7 +39,7 @@ def register(mcp: FastMCP) -> int:
         Nombre d'outils enregistrés (7)
     """
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def bank_read(
         space_id: Annotated[str, Field(description="Identifiant de l'espace")],
         filename: Annotated[str, Field(description="Nom du fichier bank (ex: 'activeContext.md', 'progress.md')")],
@@ -120,7 +121,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "bank")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def bank_read_all(
         space_id: Annotated[str, Field(description="Identifiant de l'espace")],
     ) -> dict:
@@ -178,7 +179,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "bank")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def bank_list(
         space_id: Annotated[str, Field(description="Identifiant de l'espace")],
     ) -> dict:
@@ -233,7 +234,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "bank")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=False))
     async def bank_consolidate(
         space_id: Annotated[str, Field(description="Identifiant de l'espace à consolider")],
         agent: Annotated[str, Field(default="", description="Nom de l'agent dont consolider les notes (vide = toutes, admin requis)")] = "",
@@ -339,7 +340,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "bank")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True))
     async def bank_repair(
         space_id: Annotated[str, Field(description="Identifiant de l'espace à réparer")],
         dry_run: Annotated[bool, Field(default=True, description="True = scan seul (liste les fichiers à réparer), False = applique les corrections")] = True,
@@ -504,7 +505,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "bank")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True))
     async def bank_write(
         space_id: Annotated[str, Field(description="Identifiant de l'espace")],
         filename: Annotated[str, Field(description="Nom du fichier bank (ex: 'activeContext.md')")],
@@ -592,7 +593,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "bank")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
     async def bank_delete(
         space_id: Annotated[str, Field(description="Identifiant de l'espace")],
         filename: Annotated[str, Field(description="Nom du fichier bank à supprimer")],

--- a/src/live_mem/tools/graph.py
+++ b/src/live_mem/tools/graph.py
@@ -22,6 +22,7 @@ Voir core/graph_bridge.py pour la logique métier et le client MCP Streamable HT
 from typing import Annotated
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 
@@ -36,7 +37,7 @@ def register(mcp: FastMCP) -> int:
         Nombre d'outils enregistrés (4)
     """
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True))
     async def graph_connect(
         space_id: Annotated[str, Field(description="Identifiant du space live-memory à connecter")],
         url: Annotated[str, Field(description="URL de Graph Memory (ex: 'http://localhost:8080/mcp' ou 'http://localhost:8080')")],
@@ -89,7 +90,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "graph")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True))
     async def graph_push(
         space_id: Annotated[str, Field(description="Identifiant du space live-memory à synchroniser")],
     ) -> dict:
@@ -130,7 +131,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "graph")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def graph_status(
         space_id: Annotated[str, Field(description="Identifiant du space live-memory")],
     ) -> dict:
@@ -161,7 +162,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "graph")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True))
     async def graph_disconnect(
         space_id: Annotated[str, Field(description="Identifiant du space live-memory à déconnecter")],
     ) -> dict:

--- a/src/live_mem/tools/live.py
+++ b/src/live_mem/tools/live.py
@@ -26,6 +26,7 @@ Catégories standard :
 from typing import Annotated
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 
@@ -40,7 +41,7 @@ def register(mcp: FastMCP) -> int:
         Nombre d'outils enregistrés (3)
     """
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=False))
     async def live_note(
         space_id: Annotated[str, Field(description="Identifiant de l'espace cible")],
         category: Annotated[str, Field(description="Catégorie : observation|decision|todo|insight|question|progress|issue")],
@@ -90,7 +91,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "live")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def live_read(
         space_id: Annotated[str, Field(description="Identifiant de l'espace cible")],
         limit: Annotated[int, Field(default=50, description="Nombre max de notes à retourner (défaut 50)")] = 50,
@@ -133,7 +134,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "live")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def live_search(
         space_id: Annotated[str, Field(description="Identifiant de l'espace cible")],
         query: Annotated[str, Field(description="Texte à chercher dans les notes (case-insensitive)")],

--- a/src/live_mem/tools/space.py
+++ b/src/live_mem/tools/space.py
@@ -22,6 +22,7 @@ des permissions via les helpers auth/context.py.
 from typing import Annotated
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 
@@ -36,7 +37,7 @@ def register(mcp: FastMCP) -> int:
         Nombre d'outils enregistrés (9)
     """
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=False))
     async def space_create(
         space_id: Annotated[str, Field(description="Identifiant unique de l'espace (alphanum + tirets, max 64 chars)")],
         description: Annotated[str, Field(description="Description courte de l'espace")],
@@ -121,7 +122,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "space")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True))
     async def space_update(
         space_id: Annotated[str, Field(description="Identifiant de l'espace à modifier")],
         description: Annotated[str, Field(default="", description="Nouvelle description (vide = pas de changement)")] = "",
@@ -162,7 +163,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "space")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True))
     async def space_update_rules(
         space_id: Annotated[str, Field(description="Identifiant de l'espace")],
         rules: Annotated[str, Field(description="Nouveau contenu Markdown des rules")],
@@ -204,7 +205,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "space")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def space_list() -> dict:
         """
         Liste tous les espaces mémoire accessibles par le token courant.
@@ -235,7 +236,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "space")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def space_info(
         space_id: Annotated[str, Field(description="Identifiant de l'espace")],
     ) -> dict:
@@ -264,7 +265,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "space")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def space_rules(
         space_id: Annotated[str, Field(description="Identifiant de l'espace")],
     ) -> dict:
@@ -294,7 +295,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "space")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def space_summary(
         space_id: Annotated[str, Field(description="Identifiant de l'espace")],
     ) -> dict:
@@ -323,7 +324,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "space")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def space_export(
         space_id: Annotated[str, Field(description="Identifiant de l'espace à exporter")],
     ) -> dict:
@@ -352,7 +353,7 @@ def register(mcp: FastMCP) -> int:
             from ..auth.context import safe_error
             return safe_error(e, "space")
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
     async def space_delete(
         space_id: Annotated[str, Field(description="Identifiant de l'espace à supprimer")],
         confirm: Annotated[bool, Field(default=False, description="Doit être True pour confirmer la suppression (sécurité)")] = False,

--- a/src/live_mem/tools/system.py
+++ b/src/live_mem/tools/system.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Optional
 
 from mcp.server.fastmcp import FastMCP, Context
+from mcp.types import ToolAnnotations
 
 
 def register(mcp: FastMCP) -> int:
@@ -29,7 +30,7 @@ def register(mcp: FastMCP) -> int:
         Nombre d'outils enregistrés (3)
     """
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def system_health() -> dict:
         """
         Vérifie l'état de santé du service Live Memory.
@@ -109,7 +110,7 @@ def register(mcp: FastMCP) -> int:
             "spaces_count": spaces_count,
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def system_about() -> dict:
         """
         Informations sur le service Live Memory MCP.
@@ -144,7 +145,7 @@ def register(mcp: FastMCP) -> int:
             "tools": tools,
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def system_whoami() -> dict:
         """
         Identité du token courant utilisé pour contacter le serveur.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for startup configuration validation.
+"""
+
+import os
+import pytest
+from unittest.mock import patch
+
+from live_mem.config import Settings
+
+
+def _make_settings(**overrides):
+    """Create Settings with sensible defaults, overridden by kwargs."""
+    defaults = {
+        "mcp_server_name": "Test",
+        "mcp_server_host": "0.0.0.0",
+        "mcp_server_port": 8002,
+        "mcp_server_debug": False,
+        "admin_bootstrap_key": "change_me_in_production",
+        "s3_endpoint_url": "",
+        "s3_access_key_id": "",
+        "s3_secret_access_key": "",
+        "s3_bucket_name": "live-mem",
+        "s3_region_name": "fr1",
+        "llmaas_api_url": "",
+        "llmaas_api_key": "",
+        "llmaas_model": "test-model",
+        "llmaas_max_tokens": 1000,
+        "llmaas_temperature": 0.3,
+        "default_rules_file": "",
+        "consolidation_timeout": 600,
+        "consolidation_max_notes": 500,
+        "consolidation_batch_size": 5,
+        "response_max_bytes": 512 * 1024,
+    }
+    defaults.update(overrides)
+    # Use model_construct to bypass env file loading, then validate
+    s = Settings.model_validate(defaults)
+    return s
+
+
+class TestPortValidation:
+
+    def test_valid_port(self):
+        s = _make_settings(mcp_server_port=8080)
+        assert s.mcp_server_port == 8080
+
+    def test_port_zero_rejected(self):
+        with pytest.raises(ValueError, match="MCP_SERVER_PORT"):
+            _make_settings(mcp_server_port=0)
+
+    def test_port_too_high_rejected(self):
+        with pytest.raises(ValueError, match="MCP_SERVER_PORT"):
+            _make_settings(mcp_server_port=70000)
+
+
+class TestS3Validation:
+
+    def test_all_s3_fields_set(self):
+        s = _make_settings(
+            s3_endpoint_url="http://minio:9000",
+            s3_access_key_id="key",
+            s3_secret_access_key="secret",
+        )
+        assert s.s3_endpoint_url == "http://minio:9000"
+
+    def test_partial_s3_rejected(self):
+        with pytest.raises(ValueError, match="S3 partially"):
+            _make_settings(
+                s3_endpoint_url="http://minio:9000",
+                s3_access_key_id="",
+                s3_secret_access_key="secret",
+            )
+
+    def test_s3_url_must_start_with_http(self):
+        with pytest.raises(ValueError, match="S3_ENDPOINT_URL must start"):
+            _make_settings(
+                s3_endpoint_url="ftp://minio:9000",
+                s3_access_key_id="key",
+                s3_secret_access_key="secret",
+            )
+
+    def test_no_s3_is_ok(self):
+        """All S3 fields empty is valid (unconfigured)."""
+        s = _make_settings(
+            s3_endpoint_url="",
+            s3_access_key_id="",
+            s3_secret_access_key="",
+        )
+        assert s.s3_endpoint_url == ""
+
+
+class TestLLMValidation:
+
+    def test_both_llm_fields_set(self):
+        s = _make_settings(
+            llmaas_api_url="https://api.example.com/v1",
+            llmaas_api_key="sk-test",
+        )
+        assert s.llmaas_api_url == "https://api.example.com/v1"
+
+    def test_partial_llm_rejected(self):
+        with pytest.raises(ValueError, match="LLMaaS partially"):
+            _make_settings(
+                llmaas_api_url="https://api.example.com/v1",
+                llmaas_api_key="",
+            )
+
+    def test_no_llm_is_ok(self):
+        s = _make_settings(llmaas_api_url="", llmaas_api_key="")
+        assert s.llmaas_api_url == ""
+
+
+class TestConsolidationValidation:
+
+    def test_timeout_too_low(self):
+        with pytest.raises(ValueError, match="CONSOLIDATION_TIMEOUT"):
+            _make_settings(consolidation_timeout=5)
+
+    def test_max_notes_zero(self):
+        with pytest.raises(ValueError, match="CONSOLIDATION_MAX_NOTES"):
+            _make_settings(consolidation_max_notes=0)
+
+    def test_batch_size_zero(self):
+        with pytest.raises(ValueError, match="CONSOLIDATION_BATCH_SIZE"):
+            _make_settings(consolidation_batch_size=0)
+
+
+class TestTemperatureValidation:
+
+    def test_temperature_out_of_range(self):
+        with pytest.raises(ValueError, match="LLMAAS_TEMPERATURE"):
+            _make_settings(llmaas_temperature=3.0)
+
+    def test_temperature_negative(self):
+        with pytest.raises(ValueError, match="LLMAAS_TEMPERATURE"):
+            _make_settings(llmaas_temperature=-0.5)
+
+    def test_temperature_boundaries(self):
+        _make_settings(llmaas_temperature=0.0)
+        _make_settings(llmaas_temperature=2.0)
+
+
+class TestResponseLimitValidation:
+
+    def test_response_limit_too_low(self):
+        with pytest.raises(ValueError, match="RESPONSE_MAX_BYTES"):
+            _make_settings(response_max_bytes=100)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,328 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for production ASGI middleware stack.
+
+Tests: RequestIdMiddleware, MetricsMiddleware, ResponseLimitMiddleware,
+       AuditMiddleware.
+"""
+
+import json
+import asyncio
+import pytest
+
+from live_mem.middleware import (
+    RequestIdMiddleware,
+    MetricsMiddleware,
+    ResponseLimitMiddleware,
+    AuditMiddleware,
+    current_request_id,
+)
+
+
+# ─────────────────────────────────────────────────────────────
+# Helpers — minimal ASGI test harness
+# ─────────────────────────────────────────────────────────────
+
+def _make_scope(path="/test", method="GET", headers=None):
+    """Create a minimal ASGI HTTP scope."""
+    return {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": headers or [],
+        "query_string": b"",
+        "client": ("127.0.0.1", 54321),
+    }
+
+
+async def _dummy_receive():
+    return {"type": "http.request", "body": b""}
+
+
+def _echo_app(status=200, body=b'{"ok":true}', content_type=b"application/json"):
+    """ASGI app that returns a fixed response."""
+    async def app(scope, receive, send):
+        await send({
+            "type": "http.response.start",
+            "status": status,
+            "headers": [
+                (b"content-type", content_type),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        })
+        await send({
+            "type": "http.response.body",
+            "body": body,
+        })
+    return app
+
+
+async def _collect_response(app, scope):
+    """Run an ASGI app and collect the response parts."""
+    messages = []
+    async def send(msg):
+        messages.append(msg)
+    await app(scope, _dummy_receive, send)
+    return messages
+
+
+# =============================================================================
+# RequestIdMiddleware
+# =============================================================================
+
+class TestRequestIdMiddleware:
+
+    @pytest.mark.asyncio
+    async def test_adds_request_id_header(self):
+        app = RequestIdMiddleware(_echo_app())
+        msgs = await _collect_response(app, _make_scope())
+
+        start = msgs[0]
+        headers = dict(start["headers"])
+        assert b"x-request-id" in headers
+        rid = headers[b"x-request-id"].decode()
+        assert len(rid) == 12  # hex[:12]
+
+    @pytest.mark.asyncio
+    async def test_request_id_available_in_contextvar(self):
+        captured_id = None
+
+        async def capture_app(scope, receive, send):
+            nonlocal captured_id
+            captured_id = current_request_id.get()
+            await _echo_app()(scope, receive, send)
+
+        app = RequestIdMiddleware(capture_app)
+        await _collect_response(app, _make_scope())
+
+        assert captured_id is not None
+        assert captured_id != "-"
+        assert len(captured_id) == 12
+
+    @pytest.mark.asyncio
+    async def test_different_requests_get_different_ids(self):
+        ids = []
+
+        async def capture_app(scope, receive, send):
+            ids.append(current_request_id.get())
+            await _echo_app()(scope, receive, send)
+
+        app = RequestIdMiddleware(capture_app)
+        await _collect_response(app, _make_scope())
+        await _collect_response(app, _make_scope())
+
+        assert len(ids) == 2
+        assert ids[0] != ids[1]
+
+    @pytest.mark.asyncio
+    async def test_passthrough_non_http(self):
+        called = False
+        async def inner(scope, receive, send):
+            nonlocal called
+            called = True
+        app = RequestIdMiddleware(inner)
+        await app({"type": "websocket"}, _dummy_receive, lambda m: None)
+        assert called
+
+
+# =============================================================================
+# MetricsMiddleware
+# =============================================================================
+
+class TestMetricsMiddleware:
+
+    @pytest.mark.asyncio
+    async def test_counts_requests(self):
+        app = MetricsMiddleware(_echo_app())
+        await _collect_response(app, _make_scope("/mcp"))
+        await _collect_response(app, _make_scope("/mcp"))
+        await _collect_response(app, _make_scope("/api/spaces"))
+
+        assert app._request_count["/mcp"] == 2
+        assert app._request_count["/api/spaces"] == 1
+
+    @pytest.mark.asyncio
+    async def test_counts_errors(self):
+        app = MetricsMiddleware(_echo_app(status=500))
+        await _collect_response(app, _make_scope("/mcp"))
+
+        assert app._error_count["/mcp"] == 1
+
+    @pytest.mark.asyncio
+    async def test_tracks_latency(self):
+        app = MetricsMiddleware(_echo_app())
+        await _collect_response(app, _make_scope("/mcp"))
+
+        assert app._latency_ms["/mcp"] > 0
+
+    @pytest.mark.asyncio
+    async def test_normalizes_mcp_paths(self):
+        """All /mcp* paths should bucket to /mcp."""
+        app = MetricsMiddleware(_echo_app())
+        await _collect_response(app, _make_scope("/mcp"))
+        await _collect_response(app, _make_scope("/mcp/session"))
+
+        assert app._request_count["/mcp"] == 2
+
+    @pytest.mark.asyncio
+    async def test_metrics_endpoint_json(self):
+        app = MetricsMiddleware(_echo_app())
+        # Generate some traffic first
+        await _collect_response(app, _make_scope("/mcp"))
+
+        # Request /metrics with JSON accept
+        scope = _make_scope("/metrics", headers=[(b"accept", b"application/json")])
+        msgs = await _collect_response(app, scope)
+
+        body = msgs[1]["body"]
+        data = json.loads(body)
+        assert "uptime_seconds" in data
+        assert "total_requests" in data
+        assert "by_path" in data
+
+    @pytest.mark.asyncio
+    async def test_metrics_endpoint_prometheus(self):
+        app = MetricsMiddleware(_echo_app())
+        await _collect_response(app, _make_scope("/mcp"))
+
+        # Default (no Accept header) → Prometheus format
+        scope = _make_scope("/metrics")
+        msgs = await _collect_response(app, scope)
+
+        body = msgs[1]["body"].decode()
+        assert "livemem_requests_total" in body
+        assert "livemem_uptime_seconds" in body
+
+    @pytest.mark.asyncio
+    async def test_status_code_distribution(self):
+        app = MetricsMiddleware(_echo_app(status=200))
+        await _collect_response(app, _make_scope("/test"))
+
+        assert app._status_codes[200] == 1
+
+
+# =============================================================================
+# ResponseLimitMiddleware
+# =============================================================================
+
+class TestResponseLimitMiddleware:
+
+    @pytest.mark.asyncio
+    async def test_small_response_passes_through(self):
+        body = b'{"status": "ok"}'
+        app = ResponseLimitMiddleware(_echo_app(body=body), max_bytes=1024)
+        msgs = await _collect_response(app, _make_scope())
+
+        resp_body = msgs[1]["body"]
+        assert resp_body == body
+
+    @pytest.mark.asyncio
+    async def test_large_response_truncated(self):
+        body = b"x" * 2000
+        app = ResponseLimitMiddleware(
+            _echo_app(body=body, content_type=b"application/octet-stream"),
+            max_bytes=1024,
+        )
+        msgs = await _collect_response(app, _make_scope())
+
+        resp_body = msgs[1]["body"]
+        assert len(resp_body) <= 1024
+
+    @pytest.mark.asyncio
+    async def test_truncated_json_replaced_with_error(self):
+        """When a JSON response exceeds the limit, the body is replaced
+        with a structured truncation notice (not raw truncated bytes)."""
+        data = {"items": ["x" * 500] * 10}
+        body = json.dumps(data).encode()
+        app = ResponseLimitMiddleware(_echo_app(body=body), max_bytes=1024)
+        msgs = await _collect_response(app, _make_scope())
+
+        resp_body = json.loads(msgs[1]["body"])
+        assert resp_body["_truncated"] is True
+        assert "_message" in resp_body
+
+    @pytest.mark.asyncio
+    async def test_truncated_header_present(self):
+        body = b"x" * 2000
+        app = ResponseLimitMiddleware(
+            _echo_app(body=body, content_type=b"application/octet-stream"),
+            max_bytes=1024,
+        )
+        msgs = await _collect_response(app, _make_scope())
+
+        headers = dict(msgs[0]["headers"])
+        assert headers.get(b"x-response-truncated") == b"true"
+
+    @pytest.mark.asyncio
+    async def test_exactly_at_limit(self):
+        body = b"x" * 1024
+        app = ResponseLimitMiddleware(
+            _echo_app(body=body, content_type=b"application/octet-stream"),
+            max_bytes=1024,
+        )
+        msgs = await _collect_response(app, _make_scope())
+
+        resp_body = msgs[1]["body"]
+        assert len(resp_body) == 1024
+        headers = dict(msgs[0]["headers"])
+        assert b"x-response-truncated" not in headers
+
+
+# =============================================================================
+# AuditMiddleware
+# =============================================================================
+
+class TestAuditMiddleware:
+
+    @pytest.mark.asyncio
+    async def test_skips_health_path(self):
+        logged = []
+        app = AuditMiddleware(_echo_app())
+
+        # Monkey-patch audit logger
+        import live_mem.middleware as mw
+        orig = mw.audit_logger.info
+        mw.audit_logger.info = lambda msg: logged.append(msg)
+        try:
+            await _collect_response(app, _make_scope("/health"))
+        finally:
+            mw.audit_logger.info = orig
+
+        assert len(logged) == 0
+
+    @pytest.mark.asyncio
+    async def test_logs_mcp_requests(self):
+        logged = []
+        app = AuditMiddleware(_echo_app())
+
+        import live_mem.middleware as mw
+        orig = mw.audit_logger.info
+        mw.audit_logger.info = lambda msg: logged.append(msg)
+        try:
+            await _collect_response(app, _make_scope("/mcp", method="POST"))
+        finally:
+            mw.audit_logger.info = orig
+
+        assert len(logged) == 1
+        entry = json.loads(logged[0])
+        assert entry["method"] == "POST"
+        assert entry["path"] == "/mcp"
+        assert entry["event"] == "request"
+        assert "latency_ms" in entry
+
+    @pytest.mark.asyncio
+    async def test_skips_static_paths(self):
+        logged = []
+        app = AuditMiddleware(_echo_app())
+
+        import live_mem.middleware as mw
+        orig = mw.audit_logger.info
+        mw.audit_logger.info = lambda msg: logged.append(msg)
+        try:
+            await _collect_response(app, _make_scope("/static/app.js"))
+            await _collect_response(app, _make_scope("/metrics"))
+            await _collect_response(app, _make_scope("/favicon.ico"))
+        finally:
+            mw.audit_logger.info = orig
+
+        assert len(logged) == 0


### PR DESCRIPTION
## Summary

Production-readiness improvements inspired by analysis of [opsmill/infrahub-mcp#62](https://github.com/opsmill/infrahub-mcp/pull/62), adapted to live-memory's architecture.

### New middleware stack (`src/live_mem/middleware.py`)

- **RequestIdMiddleware** — UUID correlation ID per request via `contextvars`, exposed as `X-Request-Id` response header for log tracing
- **MetricsMiddleware** — per-path request counts, error rates, cumulative latency. Exposes `/metrics` in both Prometheus exposition format and JSON
- **ResponseLimitMiddleware** — truncates responses exceeding configurable limit (default 512 KB, via `RESPONSE_MAX_BYTES` env var). JSON responses get a structured error; non-JSON gets raw truncation. Adds `X-Response-Truncated` header
- **AuditMiddleware** — structured JSON audit trail on dedicated `live_mem.audit` logger: who (token identity), what (method/path), when, request_id, client IP

### Health endpoint hardened

- `/health` now **probes S3 connectivity** and returns `503` with specific failure reason when S3 is unreachable (previously always returned `200 healthy`)
- Docker/K8s health checks will now correctly detect dependency failures

### Structured logging

- **JSON log formatter** for production log aggregation (ELK, Datadog, CloudWatch)
- `LoggingMiddleware` emits structured entries with `request_id`, client identity, method, path, status code, latency

### Configuration validation

- **Fail-fast startup** validation: port range, S3 all-or-nothing, URL format, LLM pair consistency, consolidation ranges, temperature bounds
- Clear error messages listing all misconfiguration issues at once

### Tool annotations (MCP spec)

- All **38 MCP tools** annotated with `readOnlyHint`, `destructiveHint`, and `idempotentHint` per MCP specification (`ToolAnnotations`)
- Enables MCP clients to make informed safety decisions

### Docker improvements

- **Multi-stage build**: builder stage installs deps, runtime stage copies only the venv — no pip/setuptools/build tools in production image
- Added `PYTHONDONTWRITEBYTECODE=1` and `PYTHONUNBUFFERED=1`

### Unit tests

- **36 new tests** covering all middleware classes and config validation
- `tests/test_middleware.py`: RequestId, Metrics, ResponseLimit, Audit
- `tests/test_config.py`: port, S3, LLM, consolidation, temperature, response limit validation

## Stats

- **+1,106 lines** / **-73 lines** across 15 files
- 1 new module, 2 new test files
- 36 tests, all passing

## Test plan

- [x] `pytest tests/ -v` — 36/36 passing
- [ ] `docker compose build` — verify multi-stage build succeeds
- [ ] `curl localhost:8080/health` — verify S3 probe returns 503 when S3 is down
- [ ] `curl localhost:8080/metrics` — verify Prometheus format output
- [ ] Verify `X-Request-Id` header on MCP responses
- [ ] Check structured JSON logs in `docker compose logs`