### PR TITLE
fix(tokens): UX traps in space_ids and token_hash (closes #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,8 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/).
   - **Documentation contradictoire avec v1.5.0** : les `Field.description` et docstrings de `admin_create_token` (`tools/admin.py`) et `TokenService.create_token` (`core/tokens.py`) disaient encore "vide = tous les espaces", alors que la sémantique stricte v1.5.0 stipule "vide = aucun accès" pour les non-admin. Corrigé pour refléter la réalité du code.
   - **Tokens "muets" créés silencieusement** : `admin_create_token(space_ids="")` produisait un token techniquement valide mais incapable d'accéder à aucun espace existant (403 systématique). La réponse contient désormais un champ `warning_no_access` explicite quand le token résultant n'a aucun espace autorisé et n'est pas admin.
   - **Sucre syntaxique `*` / `all`** : `admin_create_token(space_ids="*")` ou `space_ids="all"` prend désormais un **snapshot** des espaces existants au moment de la création (les futurs nouveaux spaces ne sont pas inclus, pour rester aligné avec la sémantique stricte v1.5.0). La réponse inclut `snapshot_taken: true` et un message `info` détaillant la liste matérialisée.
-  - **Préfixe `sha256:` non documenté** : `_find_token_by_hash` exigeait que le hash passé à `admin_revoke_token` / `admin_delete_token` / `admin_update_token` inclue le préfixe `sha256:` retourné par `admin_list_tokens`. Si l'utilisateur copiait juste la partie hex, l'opération retournait silencieusement `Token introuvable`. La méthode normalise désormais l'entrée et accepte les deux formes (`sha256:abc...` ou `abc...`). La validation min 16 chars s'applique maintenant sur le hex pur.
-
-### Fichiers modifiés
-| Fichier | Changements |
-| --- | --- |
-| `src/live_mem/core/tokens.py` | `_find_token_by_hash` : normalisation du préfixe `sha256:`. `create_token` : sucre `*`/`all`, `warning_no_access`, docstring corrigée. |
-| `src/live_mem/tools/admin.py` | `Field.description` corrigés pour `space_ids` (sémantique v1.5.0 explicite) et `token_hash` (préfixe optionnel) sur `revoke`/`delete`/`update`. Docstring `admin_create_token` mise à jour. |
-| `FAQ.md` | Section "Comment restreindre un token à certains espaces ?" enrichie (sucre `*`/`all`, `warning_no_access`). Nouvelle FAQ sur le préfixe `sha256:` optionnel. |
-| `tests/test_tokens.py` | Nouveaux tests couvrant les 3 fixes (création muette, snapshot `*`, normalisation hash). |
+  - **Préfixe `sha256:` non documenté** : `_find_token_by_hash` exigeait que le hash passé à `admin_revoke_token` / `admin_delete_token` / `admin_update_token` inclue le préfixe `sha256:` retourné par `admin_list_tokens`. Si l'utilisateur copiait juste la partie hex, l'opération retournait silencieusement `Token introuvable`. La méthode normalise désormais l'entrée et accepte les deux formes (`sha256:abc...` ou `abc...`). La validation min 16 chars s'applique maintenant sur le hex pur, et le message d'erreur indique la longueur du hex pur (review #12).
+  - **Cohérence `admin_update_token`** (review #12) : le sucre `*`/`all` et le `warning_no_access` sont également appliqués à `update_token` (extraction d'un helper privé `_resolve_space_ids`), évitant que la même trappe UX réapparaisse lors d'une mise à jour.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Corrigé
+- **Issue #11 — Token UX traps** — Trio cohérent de bugs UX autour des tokens (pas une faille de sécurité, mais source garantie de friction à chaque onboarding).
+  - **Documentation contradictoire avec v1.5.0** : les `Field.description` et docstrings de `admin_create_token` (`tools/admin.py`) et `TokenService.create_token` (`core/tokens.py`) disaient encore "vide = tous les espaces", alors que la sémantique stricte v1.5.0 stipule "vide = aucun accès" pour les non-admin. Corrigé pour refléter la réalité du code.
+  - **Tokens "muets" créés silencieusement** : `admin_create_token(space_ids="")` produisait un token techniquement valide mais incapable d'accéder à aucun espace existant (403 systématique). La réponse contient désormais un champ `warning_no_access` explicite quand le token résultant n'a aucun espace autorisé et n'est pas admin.
+  - **Sucre syntaxique `*` / `all`** : `admin_create_token(space_ids="*")` ou `space_ids="all"` prend désormais un **snapshot** des espaces existants au moment de la création (les futurs nouveaux spaces ne sont pas inclus, pour rester aligné avec la sémantique stricte v1.5.0). La réponse inclut `snapshot_taken: true` et un message `info` détaillant la liste matérialisée.
+  - **Préfixe `sha256:` non documenté** : `_find_token_by_hash` exigeait que le hash passé à `admin_revoke_token` / `admin_delete_token` / `admin_update_token` inclue le préfixe `sha256:` retourné par `admin_list_tokens`. Si l'utilisateur copiait juste la partie hex, l'opération retournait silencieusement `Token introuvable`. La méthode normalise désormais l'entrée et accepte les deux formes (`sha256:abc...` ou `abc...`). La validation min 16 chars s'applique maintenant sur le hex pur.
+
+### Fichiers modifiés
+| Fichier | Changements |
+| --- | --- |
+| `src/live_mem/core/tokens.py` | `_find_token_by_hash` : normalisation du préfixe `sha256:`. `create_token` : sucre `*`/`all`, `warning_no_access`, docstring corrigée. |
+| `src/live_mem/tools/admin.py` | `Field.description` corrigés pour `space_ids` (sémantique v1.5.0 explicite) et `token_hash` (préfixe optionnel) sur `revoke`/`delete`/`update`. Docstring `admin_create_token` mise à jour. |
+| `FAQ.md` | Section "Comment restreindre un token à certains espaces ?" enrichie (sucre `*`/`all`, `warning_no_access`). Nouvelle FAQ sur le préfixe `sha256:` optionnel. |
+| `tests/test_tokens.py` | Nouveaux tests couvrant les 3 fixes (création muette, snapshot `*`, normalisation hash). |
+
+---
+
 ## [1.7.1] — 2026-05-04
 
 ### Corrigé

--- a/FAQ.md
+++ b/FAQ.md
@@ -91,6 +91,21 @@ python scripts/mcp_cli.py token update sha256:363... -p "read,write" -s "live-me
 - `space_ids = []` pour un **non-admin** → **aucun accès** (changed in v1.5.0, avant = tout)
 - `space_ids = []` pour un **admin** → accès à **tout** (inchangé)
 
+À la **création** d'un token via `admin_create_token`, vous pouvez utiliser :
+- `space_ids=""` (défaut) → token "muet" (aucun accès aux espaces existants). La réponse contient un champ `warning_no_access` pour vous le signaler explicitement.
+- `space_ids="a,b,c"` → liste explicite.
+- `space_ids="*"` ou `space_ids="all"` → **snapshot** de tous les espaces existants au moment de la création (pas les futurs spaces, c'est volontaire pour rester aligné avec la sémantique stricte v1.5.0).
+
+### Le hash retourné par `admin_list_tokens` contient `sha256:` — faut-il le passer tel quel ?
+
+Depuis l'issue #11, **les deux formes sont acceptées** par `admin_revoke_token`, `admin_delete_token` et `admin_update_token` :
+```bash
+admin_update_token(token_hash="sha256:f172084ef03...", space_ids="x")  # OK
+admin_update_token(token_hash="f172084ef03...", space_ids="x")          # OK aussi
+```
+
+Le minimum reste 16 caractères hex (8 octets de hash) pour éviter les collisions accidentelles.
+
 ### Que se passe-t-il quand un token crée un nouveau space ?
 
 Le space est **automatiquement ajouté** au `space_ids` du token (via `add_space_to_token()`). Ainsi un token restreint à `["projet-a"]` qui crée `projet-b` se retrouve avec `["projet-a", "projet-b"]`. Pas de deadlock UX.

--- a/src/live_mem/core/tokens.py
+++ b/src/live_mem/core/tokens.py
@@ -57,13 +57,26 @@ class TokenService:
         Retourne (index, token) ou (-1, None) si introuvable.
         Retourne (-2, None) si le préfixe est ambigu (multiple matches).
 
-        Exige un minimum de 16 caractères pour le préfixe.
+        Exige un minimum de 16 caractères pour le préfixe (hex pur ou avec
+        préfixe ``sha256:``). Le préfixe ``sha256:`` est optionnel — il est
+        accepté tel quel ou ajouté implicitement si l'utilisateur fournit
+        uniquement le hex (issue #11).
         """
-        if len(token_hash) < 16:
+        # Issue #11 fix : normaliser l'entrée pour accepter les deux formes
+        # ("sha256:abc..." comme retourné par admin_list_tokens, ou juste "abc..."
+        # qui est ce que les utilisateurs copient naturellement).
+        normalized = (
+            token_hash if token_hash.startswith("sha256:") else "sha256:" + token_hash
+        )
+
+        # La validation min 16 chars s'applique sur le hex pur (8 octets de hash),
+        # pas sur la longueur incluant le préfixe.
+        hex_only = normalized[len("sha256:"):]
+        if len(hex_only) < 16:
             return (-3, None)  # Préfixe trop court
 
         matches = [
-            (i, t) for i, t in enumerate(store.tokens) if t.hash.startswith(token_hash)
+            (i, t) for i, t in enumerate(store.tokens) if t.hash.startswith(normalized)
         ]
 
         if len(matches) == 0:
@@ -105,11 +118,24 @@ class TokenService:
         Args:
             name: Nom descriptif (ex: "agent-cline")
             permissions: "read", "read,write", ou "read,write,admin"
-            space_ids: Espaces autorisés séparés par virgules (vide = tous)
+            space_ids: Espaces autorisés séparés par virgules.
+                Sémantique v1.5.0+ pour les non-admin :
+
+                - ``""`` (vide) → **aucun accès** aux espaces existants
+                  (le token ne pourra que créer ses propres nouveaux spaces).
+                - ``"a,b,c"`` → accès uniquement à ces espaces.
+                - ``"*"`` ou ``"all"`` → snapshot des espaces existants au
+                  moment de la création (pas les futurs spaces ; aligné
+                  avec la sémantique stricte v1.5.0).
+
+                Pour les tokens admin, ``space_ids`` est ignoré (accès à tout).
             expires_in_days: Durée en jours (0 = jamais)
 
         Returns:
-            {"status": "created", "token": "lm_...", ...}
+            ``{"status": "created", "token": "lm_...", ...}``.
+            Si le token résultant n'a accès à aucun espace existant et n'est
+            pas admin, un champ ``warning_no_access`` explicite est ajouté à
+            la réponse (issue #11).
         """
         # Générer le token : préfixe + 32 bytes base64url = 46 chars
         raw_token = TOKEN_PREFIX + secrets.token_urlsafe(32)
@@ -131,8 +157,22 @@ class TokenService:
                 ),
             }
 
-        # Parser les space_ids
-        sid_list = [s.strip() for s in space_ids.split(",") if s.strip()]
+        # Issue #11 fix : sucre syntaxique "*" / "all" → snapshot des spaces
+        # existants. On évite l'import circulaire en important localement.
+        space_ids_stripped = (space_ids or "").strip()
+        snapshot_used = False
+        if space_ids_stripped.lower() in ("*", "all"):
+            from .space import get_space_service  # import local pour éviter cycles
+
+            spaces_result = await get_space_service().list_spaces()
+            if spaces_result.get("status") == "ok":
+                sid_list = [s["space_id"] for s in spaces_result.get("spaces", [])]
+            else:
+                sid_list = []
+            snapshot_used = True
+        else:
+            # Parser la liste explicite
+            sid_list = [s.strip() for s in space_ids.split(",") if s.strip()]
 
         # Calculer l'expiration
         now = datetime.now(timezone.utc)
@@ -157,7 +197,7 @@ class TokenService:
             store.tokens.append(token_info)
             await self._save_store(store)
 
-        return {
+        response = {
             "status": "created",
             "name": name,
             "token": raw_token,
@@ -166,6 +206,30 @@ class TokenService:
             "expires_at": expires_at,
             "warning": "⚠️ Ce token ne sera PLUS JAMAIS affiché !",
         }
+
+        # Issue #11 fix : signaler explicitement les tokens "muets"
+        # (non-admin avec aucun space autorisé) — ces tokens recevraient un 403
+        # sur tout espace existant. Ils peuvent toutefois créer leurs propres
+        # spaces (auto-ajoutés via add_space_to_token).
+        is_admin = "admin" in perm_list
+        if not is_admin and not sid_list:
+            response["warning_no_access"] = (
+                "⚠️ Ce token n'a accès à aucun espace existant (space_ids=[]). "
+                "Depuis v1.5.0, c'est la sémantique stricte par défaut. "
+                "Utilisez space_ids='*' pour un snapshot de tous les espaces "
+                "actuels, ou listez-les explicitement (ex: 'space-a,space-b'). "
+                "Le token peut tout de même créer ses propres nouveaux spaces."
+            )
+
+        if snapshot_used:
+            response["snapshot_taken"] = True
+            response["info"] = (
+                f"space_ids='{space_ids_stripped}' interprété comme snapshot "
+                f"des {len(sid_list)} espace(s) existant(s) au moment de la création. "
+                "Les futurs nouveaux espaces ne seront PAS automatiquement ajoutés."
+            )
+
+        return response
 
     async def list_tokens(self) -> dict:
         """

--- a/src/live_mem/core/tokens.py
+++ b/src/live_mem/core/tokens.py
@@ -88,9 +88,19 @@ class TokenService:
     def _token_not_found_or_ambiguous(self, idx: int, token_hash: str) -> dict | None:
         """Retourne un message d'erreur si le token n'est pas trouvé, ou None si OK."""
         if idx == -3:
+            # Review #12 fix : afficher la longueur du hex pur (pas du préfixé),
+            # car la validation min 16 chars s'applique sur le hex.
+            hex_part = (
+                token_hash[len("sha256:") :]
+                if token_hash.startswith("sha256:")
+                else token_hash
+            )
             return {
                 "status": "error",
-                "message": f"Hash trop court ({len(token_hash)} chars). Minimum 16 caractères requis.",
+                "message": (
+                    f"Hash hex trop court ({len(hex_part)} chars). "
+                    "Minimum 16 caractères hex requis."
+                ),
             }
         if idx == -2:
             return {
@@ -100,6 +110,50 @@ class TokenService:
         if idx == -1:
             return {"status": "not_found", "message": "Token introuvable"}
         return None
+
+    async def _resolve_space_ids(self, space_ids: str) -> tuple[list[str], bool]:
+        """
+        Résout l'argument ``space_ids`` en liste matérialisée.
+
+        Gère le sucre syntaxique ``"*"`` / ``"all"`` (snapshot des espaces
+        existants au moment de l'appel) — partagé entre ``create_token`` et
+        ``update_token`` pour garantir une UX cohérente (review #12).
+
+        Args:
+            space_ids: Chaîne d'entrée. Une liste séparée par virgules,
+                ou ``"*"``/``"all"`` (snapshot), ou vide.
+
+        Returns:
+            Tuple ``(sid_list, snapshot_used)`` :
+
+            - ``sid_list`` : liste matérialisée des space_ids
+            - ``snapshot_used`` : ``True`` si le sucre ``*``/``all`` a été
+              utilisé (la réponse appelante ajoutera des champs informatifs).
+        """
+        space_ids_stripped = (space_ids or "").strip()
+        if space_ids_stripped.lower() in ("*", "all"):
+            from .space import get_space_service  # import local pour éviter cycles
+
+            spaces_result = await get_space_service().list_spaces()
+            if spaces_result.get("status") == "ok":
+                return (
+                    [s["space_id"] for s in spaces_result.get("spaces", [])],
+                    True,
+                )
+            return ([], True)
+        return ([s.strip() for s in space_ids.split(",") if s.strip()], False)
+
+    @staticmethod
+    def _muted_token_warning() -> str:
+        """Message standard pour les tokens "muets" (issue #11)."""
+        return (
+            "⚠️ Ce token n'a accès à aucun espace existant (space_ids=[]). "
+            "Depuis v1.5.0, c'est la sémantique stricte par défaut. "
+            "Utilisez space_ids='*' pour un snapshot de tous les espaces "
+            "actuels, ou listez-les explicitement (ex: 'space-a,space-b'). "
+            "Le token peut tout de même créer ses propres nouveaux spaces."
+        )
+
 
     async def create_token(
         self,
@@ -157,22 +211,10 @@ class TokenService:
                 ),
             }
 
-        # Issue #11 fix : sucre syntaxique "*" / "all" → snapshot des spaces
-        # existants. On évite l'import circulaire en important localement.
+        # Issue #11 fix + review #12 : logique partagée avec update_token
+        # via _resolve_space_ids (sucre "*"/"all" → snapshot).
         space_ids_stripped = (space_ids or "").strip()
-        snapshot_used = False
-        if space_ids_stripped.lower() in ("*", "all"):
-            from .space import get_space_service  # import local pour éviter cycles
-
-            spaces_result = await get_space_service().list_spaces()
-            if spaces_result.get("status") == "ok":
-                sid_list = [s["space_id"] for s in spaces_result.get("spaces", [])]
-            else:
-                sid_list = []
-            snapshot_used = True
-        else:
-            # Parser la liste explicite
-            sid_list = [s.strip() for s in space_ids.split(",") if s.strip()]
+        sid_list, snapshot_used = await self._resolve_space_ids(space_ids)
 
         # Calculer l'expiration
         now = datetime.now(timezone.utc)
@@ -213,13 +255,7 @@ class TokenService:
         # spaces (auto-ajoutés via add_space_to_token).
         is_admin = "admin" in perm_list
         if not is_admin and not sid_list:
-            response["warning_no_access"] = (
-                "⚠️ Ce token n'a accès à aucun espace existant (space_ids=[]). "
-                "Depuis v1.5.0, c'est la sémantique stricte par défaut. "
-                "Utilisez space_ids='*' pour un snapshot de tous les espaces "
-                "actuels, ou listez-les explicitement (ex: 'space-a,space-b'). "
-                "Le token peut tout de même créer ses propres nouveaux spaces."
-            )
+            response["warning_no_access"] = self._muted_token_warning()
 
         if snapshot_used:
             response["snapshot_taken"] = True
@@ -357,14 +393,33 @@ class TokenService:
         VULN-03 fix : utilise _find_token_by_hash pour une correspondance
         sécurisée (min 16 chars, détection d'ambiguïté).
 
+        Review #12 fix : ``space_ids`` accepte désormais ``"*"`` ou ``"all"``
+        (snapshot des espaces existants), aligné avec ``create_token``.
+        Quand l'opération aboutit à un token "muet" (non-admin avec
+        space_ids=[]), un ``warning_no_access`` est ajouté à la réponse.
+
         Args:
             token_hash: Hash du token (min 16 chars de préfixe)
-            space_ids: Nouveaux espaces autorisés (vide = pas de changement)
+            space_ids: Nouveaux espaces autorisés.
+
+                - ``""`` (vide) → pas de changement.
+                - ``"a,b"`` → liste explicite.
+                - ``"*"`` ou ``"all"`` → snapshot des espaces existants.
             permissions: Nouvelles permissions (vide = pas de changement)
 
         Returns:
-            {"status": "ok"} ou erreur
+            ``{"status": "ok"}`` ou erreur. Si ``space_ids`` modifié et que
+            le résultat est un token muet (non-admin sans aucun space),
+            la réponse contient un champ ``warning_no_access``.
         """
+        # Pré-résoudre le sucre "*"/"all" hors du lock pour éviter
+        # de tenir le verrou pendant un appel S3 (list_spaces).
+        space_ids_stripped = (space_ids or "").strip()
+        new_space_ids: Optional[list[str]] = None
+        snapshot_used = False
+        if space_ids_stripped:
+            new_space_ids, snapshot_used = await self._resolve_space_ids(space_ids)
+
         async with get_lock_manager().tokens:
             store = await self._load_store()
 
@@ -390,14 +445,39 @@ class TokenService:
                 token.permissions = [
                     p.strip() for p in permissions.split(",") if p.strip()
                 ]
-            if space_ids:
-                token.space_ids = [s.strip() for s in space_ids.split(",")]
+            if new_space_ids is not None:
+                token.space_ids = new_space_ids
             if email:
                 token.email = email
 
             await self._save_store(store)
+            # Snapshot des champs nécessaires pour la réponse (avant sortie du lock)
+            updated_name = token.name
+            updated_space_ids = list(token.space_ids)
+            updated_perms = list(token.permissions)
 
-        return {"status": "ok", "message": f"Token '{token.name}' mis à jour"}
+        response = {
+            "status": "ok",
+            "message": f"Token '{updated_name}' mis à jour",
+        }
+
+        # Review #12 : signaler un token muet (cohérent avec create_token)
+        # uniquement si space_ids a été touché par cet appel.
+        if new_space_ids is not None:
+            is_admin = "admin" in updated_perms
+            if not is_admin and not updated_space_ids:
+                response["warning_no_access"] = self._muted_token_warning()
+
+        if snapshot_used:
+            response["snapshot_taken"] = True
+            response["info"] = (
+                f"space_ids='{space_ids_stripped}' interprété comme snapshot "
+                f"des {len(updated_space_ids)} espace(s) existant(s) au moment "
+                "de la mise à jour. Les futurs nouveaux espaces ne seront PAS "
+                "automatiquement ajoutés."
+            )
+
+        return response
 
     async def add_space_to_token(self, token_hash: str, space_id: str) -> dict:
         """

--- a/src/live_mem/tools/admin.py
+++ b/src/live_mem/tools/admin.py
@@ -53,7 +53,12 @@ def register(mcp: FastMCP) -> int:
             str,
             Field(
                 default="",
-                description="Espaces autorisés séparés par virgules (vide = tous les espaces)",
+                description=(
+                    "Espaces autorisés, séparés par virgules. Sémantique stricte v1.5.0+ : "
+                    "vide = AUCUN accès aux espaces existants (le token ne peut que "
+                    "créer ses propres nouveaux spaces). Utilisez '*' ou 'all' pour un "
+                    "snapshot des espaces actuels (pas les futurs). Ignoré pour les admins."
+                ),
             ),
         ] = "",
         expires_in_days: Annotated[
@@ -79,11 +84,16 @@ def register(mcp: FastMCP) -> int:
         Args:
             name: Nom descriptif (ex: "agent-cline")
             permissions: "read", "read,write", ou "read,write,admin"
-            space_ids: Espaces autorisés, séparés par virgules (vide = tous)
+            space_ids: Espaces autorisés (séparés par virgules). Sémantique
+                stricte v1.5.0+ : vide = AUCUN accès pour les non-admin.
+                Utilisez "*" ou "all" pour un snapshot des espaces actuels.
+                Voir FAQ.md pour les détails.
             expires_in_days: Durée en jours (0 = jamais)
 
         Returns:
-            Token en clair (à sauvegarder !), permissions, expiration
+            Token en clair (à sauvegarder !), permissions, expiration.
+            Si le token résultant n'a accès à aucun espace existant
+            (et n'est pas admin), un champ `warning_no_access` est ajouté.
         """
         from ..auth.context import check_admin_permission
         from ..core.tokens import get_token_service
@@ -135,7 +145,11 @@ def register(mcp: FastMCP) -> int:
         token_hash: Annotated[
             str,
             Field(
-                description="Hash tronqué du token à révoquer (obtenu via admin_list_tokens)"
+                description=(
+                    "Hash du token à révoquer (obtenu via admin_list_tokens). "
+                    "Préfixe 'sha256:' optionnel — accepte 'sha256:abc...' ou juste 'abc...'. "
+                    "Min 16 caractères hex requis."
+                )
             ),
         ],
     ) -> dict:
@@ -167,7 +181,10 @@ def register(mcp: FastMCP) -> int:
         token_hash: Annotated[
             str,
             Field(
-                description="Hash tronqué du token à supprimer (obtenu via admin_list_tokens)"
+                description=(
+                    "Hash du token à supprimer (obtenu via admin_list_tokens). "
+                    "Préfixe 'sha256:' optionnel. Min 16 caractères hex requis."
+                )
             ),
         ],
     ) -> dict:
@@ -244,7 +261,10 @@ def register(mcp: FastMCP) -> int:
         token_hash: Annotated[
             str,
             Field(
-                description="Hash tronqué du token à modifier (obtenu via admin_list_tokens)"
+                description=(
+                    "Hash du token à modifier (obtenu via admin_list_tokens). "
+                    "Préfixe 'sha256:' optionnel. Min 16 caractères hex requis."
+                )
             ),
         ],
         space_ids: Annotated[

--- a/src/live_mem/tools/admin.py
+++ b/src/live_mem/tools/admin.py
@@ -271,7 +271,11 @@ def register(mcp: FastMCP) -> int:
             str,
             Field(
                 default="",
-                description="Nouveaux espaces autorisés séparés par virgules (vide = pas de changement)",
+                description=(
+                    "Nouveaux espaces autorisés, séparés par virgules. "
+                    "Vide = pas de changement. Utilisez '*' ou 'all' pour un "
+                    "snapshot des espaces existants (cohérent avec admin_create_token)."
+                ),
             ),
         ] = "",
         permissions: Annotated[

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for issue #11 fixes in TokenService.
+
+Coverage:
+    - `_find_token_by_hash` accepte les deux formes (avec/sans préfixe sha256:).
+    - `_find_token_by_hash` rejette les hashes hex < 16 caractères.
+    - `create_token` ajoute `warning_no_access` pour les tokens muets non-admin.
+    - `create_token` n'ajoute PAS `warning_no_access` pour les tokens admin.
+    - `create_token` n'ajoute PAS `warning_no_access` quand des spaces sont fournis.
+    - `create_token(space_ids="*")` matérialise un snapshot des spaces existants.
+    - `create_token(space_ids="all")` est synonyme de `*`.
+"""
+
+import hashlib
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from live_mem.core.tokens import TokenService
+from live_mem.core.models import TokenInfo, TokensStore
+
+
+# ─────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────
+
+
+def _make_token(name: str, suffix: str = "0" * 64, **kwargs) -> TokenInfo:
+    """Crée un TokenInfo avec un hash déterministe pour les tests."""
+    return TokenInfo(
+        hash=f"sha256:{suffix}",
+        name=name,
+        permissions=kwargs.pop("permissions", ["read"]),
+        space_ids=kwargs.pop("space_ids", []),
+        created_at="2026-05-05T00:00:00+00:00",
+        **kwargs,
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# Tests : _find_token_by_hash — normalisation du préfixe sha256:
+# ─────────────────────────────────────────────────────────────
+
+
+def test_find_token_accepts_full_prefixed_hash():
+    """Le hash complet 'sha256:<hex>' doit fonctionner (rétrocompat)."""
+    svc = TokenService()
+    h = "a" * 64
+    store = TokensStore(tokens=[_make_token("alpha", suffix=h)])
+
+    idx, token = svc._find_token_by_hash(store, f"sha256:{h}")
+
+    assert idx == 0
+    assert token is not None
+    assert token.name == "alpha"
+
+
+def test_find_token_accepts_hex_only():
+    """Issue #11 : le hash hex sans préfixe doit fonctionner aussi."""
+    svc = TokenService()
+    h = "b" * 64
+    store = TokensStore(tokens=[_make_token("beta", suffix=h)])
+
+    idx, token = svc._find_token_by_hash(store, h)
+
+    assert idx == 0
+    assert token is not None
+    assert token.name == "beta"
+
+
+def test_find_token_accepts_truncated_hex_only():
+    """Issue #11 : un préfixe hex (>=16 chars) sans 'sha256:' doit matcher."""
+    svc = TokenService()
+    h = "c" * 64
+    store = TokensStore(tokens=[_make_token("gamma", suffix=h)])
+
+    # 16 chars hex (minimum)
+    idx, token = svc._find_token_by_hash(store, h[:16])
+
+    assert idx == 0
+    assert token.name == "gamma"
+
+
+def test_find_token_accepts_truncated_with_prefix():
+    """Le préfixe sha256: + hex tronqué fonctionne aussi (rétrocompat CLI)."""
+    svc = TokenService()
+    h = "d" * 64
+    store = TokensStore(tokens=[_make_token("delta", suffix=h)])
+
+    # sha256:dddddddddddddddd → 16 chars hex
+    idx, token = svc._find_token_by_hash(store, f"sha256:{h[:16]}")
+
+    assert idx == 0
+    assert token.name == "delta"
+
+
+def test_find_token_rejects_too_short_hex():
+    """Hash hex < 16 chars doit être rejeté."""
+    svc = TokenService()
+    h = "e" * 64
+    store = TokensStore(tokens=[_make_token("epsilon", suffix=h)])
+
+    idx, token = svc._find_token_by_hash(store, h[:15])  # 15 chars
+
+    assert idx == -3
+    assert token is None
+
+
+def test_find_token_rejects_too_short_with_prefix():
+    """sha256: + hex < 16 chars doit aussi être rejeté."""
+    svc = TokenService()
+    h = "f" * 64
+    store = TokensStore(tokens=[_make_token("phi", suffix=h)])
+
+    idx, token = svc._find_token_by_hash(store, f"sha256:{h[:10]}")
+
+    assert idx == -3
+
+
+def test_find_token_not_found():
+    """Hash valide mais inexistant retourne -1."""
+    svc = TokenService()
+    store = TokensStore(tokens=[_make_token("zeta", suffix="9" * 64)])
+
+    idx, token = svc._find_token_by_hash(store, "0" * 32)
+
+    assert idx == -1
+
+
+def test_find_token_ambiguous_prefix():
+    """Préfixe matchant plusieurs tokens retourne -2."""
+    svc = TokenService()
+    # Deux tokens partageant les 16 premiers caractères hex
+    common = "abcdef0123456789"
+    store = TokensStore(
+        tokens=[
+            _make_token("first", suffix=common + "1" * 48),
+            _make_token("second", suffix=common + "2" * 48),
+        ]
+    )
+
+    idx, token = svc._find_token_by_hash(store, common)  # exactement 16 chars
+
+    assert idx == -2
+
+
+# ─────────────────────────────────────────────────────────────
+# Tests : create_token — warning_no_access et sucre */all
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_token_empty_space_ids_warns_for_non_admin():
+    """Issue #11 : un token non-admin créé sans space_ids doit recevoir un warning."""
+    svc = TokenService()
+
+    # Mock du store S3 pour éviter le réseau
+    with patch.object(svc, "_load_store", new=AsyncMock(return_value=TokensStore())), \
+         patch.object(svc, "_save_store", new=AsyncMock()):
+        result = await svc.create_token(
+            name="muet", permissions="read,write", space_ids=""
+        )
+
+    assert result["status"] == "created"
+    assert result["space_ids"] == []
+    assert "warning_no_access" in result, (
+        "Un token non-admin sans space_ids doit déclencher warning_no_access"
+    )
+    assert "aucun espace" in result["warning_no_access"].lower()
+
+
+@pytest.mark.asyncio
+async def test_create_token_empty_space_ids_no_warn_for_admin():
+    """Un token admin sans space_ids n'a PAS besoin de warning (bypass check_access)."""
+    svc = TokenService()
+
+    with patch.object(svc, "_load_store", new=AsyncMock(return_value=TokensStore())), \
+         patch.object(svc, "_save_store", new=AsyncMock()):
+        result = await svc.create_token(
+            name="admin-tok", permissions="read,write,admin", space_ids=""
+        )
+
+    assert result["status"] == "created"
+    assert "warning_no_access" not in result
+
+
+@pytest.mark.asyncio
+async def test_create_token_with_explicit_spaces_no_warn():
+    """Une liste explicite de spaces ne doit pas déclencher de warning."""
+    svc = TokenService()
+
+    with patch.object(svc, "_load_store", new=AsyncMock(return_value=TokensStore())), \
+         patch.object(svc, "_save_store", new=AsyncMock()):
+        result = await svc.create_token(
+            name="restreint",
+            permissions="read,write",
+            space_ids="projet-a,projet-b",
+        )
+
+    assert result["status"] == "created"
+    assert result["space_ids"] == ["projet-a", "projet-b"]
+    assert "warning_no_access" not in result
+
+
+@pytest.mark.asyncio
+async def test_create_token_star_takes_snapshot():
+    """Issue #11 : space_ids='*' doit matérialiser un snapshot des spaces existants."""
+    svc = TokenService()
+
+    fake_spaces = {
+        "status": "ok",
+        "spaces": [
+            {"space_id": "alpha"},
+            {"space_id": "beta"},
+            {"space_id": "gamma"},
+        ],
+    }
+
+    fake_space_service = type(
+        "FakeSpaceService", (), {"list_spaces": AsyncMock(return_value=fake_spaces)}
+    )()
+
+    with patch.object(svc, "_load_store", new=AsyncMock(return_value=TokensStore())), \
+         patch.object(svc, "_save_store", new=AsyncMock()), \
+         patch(
+             "live_mem.core.space.get_space_service", return_value=fake_space_service
+         ):
+        result = await svc.create_token(
+            name="snapshot", permissions="read,write", space_ids="*"
+        )
+
+    assert result["status"] == "created"
+    assert result["space_ids"] == ["alpha", "beta", "gamma"]
+    assert result.get("snapshot_taken") is True
+    assert "info" in result
+    # Le warning ne doit PAS être présent puisqu'on a 3 spaces
+    assert "warning_no_access" not in result
+
+
+@pytest.mark.asyncio
+async def test_create_token_all_is_synonym_for_star():
+    """space_ids='all' doit avoir exactement le même comportement que '*'."""
+    svc = TokenService()
+
+    fake_spaces = {"status": "ok", "spaces": [{"space_id": "only-one"}]}
+    fake_space_service = type(
+        "FakeSpaceService", (), {"list_spaces": AsyncMock(return_value=fake_spaces)}
+    )()
+
+    with patch.object(svc, "_load_store", new=AsyncMock(return_value=TokensStore())), \
+         patch.object(svc, "_save_store", new=AsyncMock()), \
+         patch(
+             "live_mem.core.space.get_space_service", return_value=fake_space_service
+         ):
+        result = await svc.create_token(
+            name="all-tok", permissions="read", space_ids="all"
+        )
+
+    assert result["space_ids"] == ["only-one"]
+    assert result.get("snapshot_taken") is True
+
+
+@pytest.mark.asyncio
+async def test_create_token_star_with_no_spaces_warns():
+    """Si aucun space n'existe, snapshot vide → warning attendu pour non-admin."""
+    svc = TokenService()
+
+    fake_spaces = {"status": "ok", "spaces": []}
+    fake_space_service = type(
+        "FakeSpaceService", (), {"list_spaces": AsyncMock(return_value=fake_spaces)}
+    )()
+
+    with patch.object(svc, "_load_store", new=AsyncMock(return_value=TokensStore())), \
+         patch.object(svc, "_save_store", new=AsyncMock()), \
+         patch(
+             "live_mem.core.space.get_space_service", return_value=fake_space_service
+         ):
+        result = await svc.create_token(
+            name="empty-snap", permissions="read", space_ids="*"
+        )
+
+    assert result["space_ids"] == []
+    assert result.get("snapshot_taken") is True
+    # Le warning doit être présent : snapshot vide pour non-admin
+    assert "warning_no_access" in result
+
+
+# ─────────────────────────────────────────────────────────────
+# Tests : end-to-end via update_token (vérifie la chaîne complète)
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_token_accepts_hex_only_hash():
+    """Régression issue #11 : update_token doit accepter le hash sans préfixe."""
+    svc = TokenService()
+    h = "abcd" * 16  # 64 chars hex
+    existing = _make_token("target", suffix=h, space_ids=["old"])
+    store = TokensStore(tokens=[existing])
+
+    save_mock = AsyncMock()
+    with patch.object(svc, "_load_store", new=AsyncMock(return_value=store)), \
+         patch.object(svc, "_save_store", new=save_mock):
+        # Passe le hex pur, sans 'sha256:'
+        result = await svc.update_token(token_hash=h, space_ids="new-space")
+
+    assert result["status"] == "ok"
+    assert existing.space_ids == ["new-space"]
+    save_mock.assert_called_once()

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -12,7 +12,6 @@ Coverage:
     - `create_token(space_ids="all")` est synonyme de `*`.
 """
 
-import hashlib
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -308,3 +307,141 @@ async def test_update_token_accepts_hex_only_hash():
     assert result["status"] == "ok"
     assert existing.space_ids == ["new-space"]
     save_mock.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────
+# Tests : review #12 — corrections du second tour
+# ─────────────────────────────────────────────────────────────
+
+
+def test_find_token_error_message_uses_hex_length():
+    """Review #12 : le message d'erreur doit indiquer la longueur du hex pur,
+    pas celle incluant le préfixe 'sha256:'."""
+    svc = TokenService()
+    store = TokensStore(tokens=[])
+
+    # Hash "sha256:abc" = 11 chars total, mais 3 chars hex.
+    too_short_with_prefix = "sha256:abc"
+    idx, _ = svc._find_token_by_hash(store, too_short_with_prefix)
+    err = svc._token_not_found_or_ambiguous(idx, too_short_with_prefix)
+
+    assert err is not None
+    # Le message doit parler de "3 chars" (hex pur), pas de "11 chars"
+    assert "3 chars" in err["message"]
+    assert "hex" in err["message"].lower()
+    assert "11" not in err["message"]
+
+
+@pytest.mark.asyncio
+async def test_update_token_star_takes_snapshot():
+    """Review #12 : update_token(space_ids='*') doit matérialiser un snapshot
+    des espaces existants (cohérence avec create_token)."""
+    svc = TokenService()
+    h = "1234" * 16  # 64 chars hex
+    existing = _make_token("targ", suffix=h, space_ids=["legacy"])
+    store = TokensStore(tokens=[existing])
+
+    fake_spaces = {
+        "status": "ok",
+        "spaces": [
+            {"space_id": "alpha"},
+            {"space_id": "beta"},
+        ],
+    }
+    fake_space_service = type(
+        "FakeSpaceService", (), {"list_spaces": AsyncMock(return_value=fake_spaces)}
+    )()
+
+    with patch.object(svc, "_load_store", new=AsyncMock(return_value=store)), \
+         patch.object(svc, "_save_store", new=AsyncMock()), \
+         patch(
+             "live_mem.core.space.get_space_service", return_value=fake_space_service
+         ):
+        result = await svc.update_token(token_hash=h, space_ids="*")
+
+    assert result["status"] == "ok"
+    assert result.get("snapshot_taken") is True
+    assert "info" in result
+    # Le token doit avoir été matérialisé avec les 2 spaces du snapshot
+    assert existing.space_ids == ["alpha", "beta"]
+
+
+@pytest.mark.asyncio
+async def test_update_token_warns_when_star_yields_empty_list():
+    """Review #12 : si update_token(space_ids='*') sur une instance sans
+    aucun space, le token devient muet → warning_no_access attendu (non-admin)."""
+    svc = TokenService()
+    h = "5678" * 16
+    existing = _make_token(
+        "muet-update", suffix=h, permissions=["read", "write"], space_ids=["legacy"]
+    )
+    store = TokensStore(tokens=[existing])
+
+    fake_spaces = {"status": "ok", "spaces": []}  # Aucun space dans l'instance
+    fake_space_service = type(
+        "FakeSpaceService", (), {"list_spaces": AsyncMock(return_value=fake_spaces)}
+    )()
+
+    with patch.object(svc, "_load_store", new=AsyncMock(return_value=store)), \
+         patch.object(svc, "_save_store", new=AsyncMock()), \
+         patch(
+             "live_mem.core.space.get_space_service", return_value=fake_space_service
+         ):
+        result = await svc.update_token(token_hash=h, space_ids="*")
+
+    assert result["status"] == "ok"
+    assert existing.space_ids == []
+    # Token muet → warning attendu pour non-admin
+    assert "warning_no_access" in result
+
+
+@pytest.mark.asyncio
+async def test_update_token_empty_space_ids_no_change():
+    """update_token(space_ids='') ne doit pas toucher aux space_ids existants
+    (sémantique 'vide = pas de changement', inchangée)."""
+    svc = TokenService()
+    h = "9abc" * 16
+    existing = _make_token("keep-old", suffix=h, space_ids=["projet-a", "projet-b"])
+    store = TokensStore(tokens=[existing])
+
+    with patch.object(svc, "_load_store", new=AsyncMock(return_value=store)), \
+         patch.object(svc, "_save_store", new=AsyncMock()):
+        result = await svc.update_token(token_hash=h, space_ids="", email="new@x")
+
+    assert result["status"] == "ok"
+    # Liste inchangée
+    assert existing.space_ids == ["projet-a", "projet-b"]
+    assert existing.email == "new@x"
+    # Pas de warning car space_ids n'a pas été touché
+    assert "warning_no_access" not in result
+
+
+@pytest.mark.asyncio
+async def test_update_token_admin_no_warning_when_emptied():
+    """Un admin avec space_ids vidé (via *) ne doit PAS recevoir warning_no_access."""
+    svc = TokenService()
+    h = "deff" * 16
+    existing = _make_token(
+        "admin-tok",
+        suffix=h,
+        permissions=["read", "write", "admin"],
+        space_ids=["legacy"],
+    )
+    store = TokensStore(tokens=[existing])
+
+    fake_spaces = {"status": "ok", "spaces": []}
+    fake_space_service = type(
+        "FakeSpaceService", (), {"list_spaces": AsyncMock(return_value=fake_spaces)}
+    )()
+
+    with patch.object(svc, "_load_store", new=AsyncMock(return_value=store)), \
+         patch.object(svc, "_save_store", new=AsyncMock()), \
+         patch(
+             "live_mem.core.space.get_space_service", return_value=fake_space_service
+         ):
+        result = await svc.update_token(token_hash=h, space_ids="*")
+
+    assert result["status"] == "ok"
+    assert existing.space_ids == []
+    # Admin → pas de warning (bypass check_access)
+    assert "warning_no_access" not in result


### PR DESCRIPTION
## Closes #11

Trio cohérent de bugs UX autour de la création/manipulation des tokens, tous liés à la sémantique stricte v1.5.0 (`space_ids=[]` → "aucun accès" pour les non-admin). **Pas une faille de sécurité** — la sémantique est correcte et voulue — mais source garantie de friction et de tickets support à chaque onboarding d'agent.

## Le trio de bugs corrigés

### 1. 📝 Documentation alignée sur le comportement v1.5.0

Les `Field.description` et docstrings de `admin_create_token` et `TokenService.create_token` disaient encore *"vide = tous les espaces"*, alors que la sémantique réelle depuis v1.5.0 est *"vide = aucun accès"* pour les non-admin. C'est la cause racine du bug #2 : les agents/users se basent sur cette doc et créent des tokens muets.

**Fichiers** : `src/live_mem/tools/admin.py`, `src/live_mem/core/tokens.py`, `FAQ.md`.

### 2. 🚨 Garde-fou explicite contre les tokens "muets"

`admin_create_token(space_ids="")` produisait un token techniquement valide mais incapable d'accéder à aucun espace existant (403 systématique). La migration `migrate_empty_space_ids()` ne s'applique qu'au démarrage pour les tokens existants — tout token créé après reste muet pour toujours.

**Fix** : la réponse contient désormais un champ `warning_no_access` explicite quand le token résultant n'a aucun espace autorisé et n'est pas admin.

```json
{
  "status": "created",
  "token": "lm_...",
  "space_ids": [],
  "warning_no_access": "⚠️ Ce token n'a accès à aucun espace existant (space_ids=[]). Depuis v1.5.0, c'est la sémantique stricte par défaut. Utilisez space_ids='*' pour un snapshot de tous les espaces actuels, ou listez-les explicitement (ex: 'space-a,space-b'). Le token peut tout de même créer ses propres nouveaux spaces."
}
```

### 3. 🍬 Sucre syntaxique `space_ids="*"` / `"all"`

`admin_create_token(space_ids="*")` ou `space_ids="all"` prend désormais un **snapshot** des espaces existants au moment de la création (via `SpaceService.list_spaces()`). Les futurs nouveaux spaces ne sont **pas** automatiquement ajoutés, pour rester strictement aligné avec la sémantique v1.5.0 — c'est un choix conscient et documenté dans la réponse :

```json
{
  "status": "created",
  "space_ids": ["alpha", "beta", "gamma"],
  "snapshot_taken": true,
  "info": "space_ids='*' interprété comme snapshot des 3 espace(s) existant(s) au moment de la création. Les futurs nouveaux espaces ne seront PAS automatiquement ajoutés."
}
```

### 4. 🔑 Normalisation du préfixe `sha256:` (option A de l'issue)

`_find_token_by_hash()` exigeait que le hash passé à `admin_revoke_token` / `admin_delete_token` / `admin_update_token` inclue le préfixe `sha256:` retourné par `admin_list_tokens`. Si l'utilisateur copiait juste la partie hex (réflexe naturel), l'opération retournait silencieusement `Token introuvable`.

**Fix** : la méthode normalise désormais l'entrée et accepte les deux formes :

```python
admin_update_token(token_hash="sha256:f172084ef03...", space_ids="x")  # OK (rétrocompat)
admin_update_token(token_hash="f172084ef03...",       space_ids="x")  # OK (issue #11)
```

La validation min 16 chars s'applique maintenant sur le hex pur, pas sur la longueur incluant le préfixe. Les `Field.description` des 3 outils admin mentionnent désormais explicitement que le préfixe est optionnel.

## Tests

15 nouveaux tests unitaires dans `tests/test_tokens.py`, **tous passent en local (pytest 9.0.3, Python 3.11)** :

```
tests/test_tokens.py::test_find_token_accepts_full_prefixed_hash PASSED
tests/test_tokens.py::test_find_token_accepts_hex_only PASSED
tests/test_tokens.py::test_find_token_accepts_truncated_hex_only PASSED
tests/test_tokens.py::test_find_token_accepts_truncated_with_prefix PASSED
tests/test_tokens.py::test_find_token_rejects_too_short_hex PASSED
tests/test_tokens.py::test_find_token_rejects_too_short_with_prefix PASSED
tests/test_tokens.py::test_find_token_not_found PASSED
tests/test_tokens.py::test_find_token_ambiguous_prefix PASSED
tests/test_tokens.py::test_create_token_empty_space_ids_warns_for_non_admin PASSED
tests/test_tokens.py::test_create_token_empty_space_ids_no_warn_for_admin PASSED
tests/test_tokens.py::test_create_token_with_explicit_spaces_no_warn PASSED
tests/test_tokens.py::test_create_token_star_takes_snapshot PASSED
tests/test_tokens.py::test_create_token_all_is_synonym_for_star PASSED
tests/test_tokens.py::test_create_token_star_with_no_spaces_warns PASSED
tests/test_tokens.py::test_update_token_accepts_hex_only_hash PASSED
======================== 15 passed in 0.44s ========================
```

## Compatibilité & versionning

- **Rétrocompatible à 100%** : aucune signature publique n'est modifiée. Les anciens appels passant `sha256:abc...` continuent de fonctionner. Les tokens existants ne sont pas affectés.
- Pas de bump de `VERSION` dans cette PR — entrée `[Unreleased]` dans le `CHANGELOG.md`, à incorporer dans le prochain tag à votre convenance.

## Fichiers modifiés

| Fichier | Changements |
| --- | --- |
| `src/live_mem/core/tokens.py` | `_find_token_by_hash` : normalisation `sha256:`. `create_token` : sucre `*`/`all`, `warning_no_access`, docstring corrigée. |
| `src/live_mem/tools/admin.py` | `Field.description` corrigés pour `space_ids` (sémantique v1.5.0 explicite) et `token_hash` (préfixe optionnel) sur `revoke`/`delete`/`update`. |
| `FAQ.md` | Section "Comment restreindre un token à certains espaces ?" enrichie. Nouvelle FAQ sur le préfixe `sha256:` optionnel. |
| `CHANGELOG.md` | Nouvelle entrée `[Unreleased]`. |
| `tests/test_tokens.py` | 15 nouveaux tests unitaires. |
