### PR TITLE
docs: integration guides for Claude Code (FR/EN) and Cline (EN)

### DIFF
--- a/GUIDE_INTEGRATION_CLAUDE_CODE.fr.md
+++ b/GUIDE_INTEGRATION_CLAUDE_CODE.fr.md
@@ -1,0 +1,546 @@
+# 🔌 Guide d'intégration Live Memory avec Claude Code
+
+> **Version** : 1.0.0 | **Date** : 2026-05-16
+
+Ce guide détaille pas à pas comment connecter **Claude Code** (le CLI d'Anthropic, ou son extension IDE) à **Live Memory** pour lui donner une mémoire de travail partagée et persistante.
+
+---
+
+## 📋 Table des matières
+
+- [Prérequis](#-prérequis)
+- [Étape 1 — Démarrer Live Memory](#-étape-1--démarrer-live-memory)
+- [Étape 2 — Créer un token pour Claude Code](#-étape-2--créer-un-token-pour-claude-code)
+- [Étape 3 — Brancher Claude Code sur Live Memory](#-étape-3--brancher-claude-code-sur-live-memory)
+- [Étape 4 — Créer un espace mémoire](#-étape-4--créer-un-espace-mémoire)
+- [Étape 5 — Donner des instructions à Claude Code](#-étape-5--donner-des-instructions-à-claude-code)
+- [Workflow recommandé](#-workflow-recommandé)
+- [Multi-agents : Claude Code + Cline + Claude Desktop + autres](#-multi-agents--claude-code--cline--claude-desktop--autres)
+- [Dépannage](#-dépannage)
+- [Avec Claude Desktop](#-avec-claude-desktop)
+- [Récapitulatif](#-récapitulatif)
+
+---
+
+## 📦 Prérequis
+
+| Composant            | Version            | Vérification                        |
+| -------------------- | ------------------ | ----------------------------------- |
+| **Docker**           | ≥ 24.0             | `docker --version`                  |
+| **Docker Compose**   | v2                 | `docker compose version`            |
+| **Claude Code**      | ≥ 2.1              | `claude --version`                  |
+| **Live Memory**      | Déployé et running | `curl http://localhost:8080/health` |
+
+> 💡 Si Claude Code n'est pas installé : `npm install -g @anthropic-ai/claude-code` (macOS/Linux/Windows) ou via l'installateur dédié — voir la documentation officielle Anthropic. Claude Code expose la commande `claude` dans le terminal et propose des extensions IDE (VS Code, JetBrains) qui partagent la même configuration.
+
+---
+
+## 🚀 Étape 1 — Démarrer Live Memory
+
+Si Live Memory n'est pas encore démarré :
+
+```bash
+cd /chemin/vers/live-memory
+cp .env.example .env
+# Éditer .env avec vos credentials S3, LLMaaS, et ADMIN_BOOTSTRAP_KEY
+docker compose build
+docker compose up -d
+```
+
+**Vérifier** :
+
+```bash
+# Doit retourner {"status": "ok", ...}
+curl -s http://localhost:8080/health | jq .
+```
+
+---
+
+## 🔑 Étape 2 — Créer un token pour Claude Code
+
+Claude Code a besoin d'un **Bearer Token** avec les permissions `read,write` pour lire et écrire dans la mémoire.
+
+### Option A — Via la CLI
+
+```bash
+cd /chemin/vers/live-memory
+export MCP_TOKEN=<votre_ADMIN_BOOTSTRAP_KEY>
+
+# Créer un token "read,write" pour Claude Code
+python scripts/mcp_cli.py token create claude-code-agent read,write
+```
+
+La CLI affichera quelque chose comme :
+
+```
+Token créé avec succès !
+  Nom    : claude-code-agent
+  Token  : lm_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9T0u1V2
+  Perms  : read, write
+
+⚠️  Ce token ne sera PLUS JAMAIS affiché. Copiez-le maintenant !
+```
+
+> **⚠️ IMPORTANT** : Copiez ce token immédiatement ! Il ne sera plus jamais affiché (seul le hash SHA-256 est stocké).
+
+### Option B — Via la bootstrap key (temporaire)
+
+Pour un test rapide, vous pouvez utiliser directement la `ADMIN_BOOTSTRAP_KEY` définie dans votre `.env`. Mais **en production**, créez toujours un token dédié avec les permissions minimales.
+
+---
+
+## ⚙️ Étape 3 — Brancher Claude Code sur Live Memory
+
+Claude Code stocke sa configuration MCP dans un fichier JSON. Trois scopes sont disponibles :
+
+| Scope     | Emplacement                                  | Portée                              |
+| --------- | -------------------------------------------- | ----------------------------------- |
+| `local`   | `~/.claude.json` (clé `projects.<cwd>`)      | Le répertoire courant uniquement    |
+| `user`    | `~/.claude.json` (clé `mcpServers` globale)  | Tous les projets de l'utilisateur   |
+| `project` | `.mcp.json` à la racine du projet            | Commité dans le repo (équipes)      |
+
+Pour une utilisation perso multi-projets, le scope `user` est généralement le plus pratique.
+
+### 3.1 — Méthode CLI (recommandée)
+
+```bash
+claude mcp add \
+  --transport http \
+  --scope user \
+  live-memory \
+  https://votre-serveur/mcp \
+  --header "Authorization: Bearer lm_VOTRE_TOKEN_ICI"
+```
+
+Pour un serveur local en HTTP :
+
+```bash
+claude mcp add \
+  --transport http \
+  --scope user \
+  live-memory \
+  http://localhost:8080/mcp \
+  --header "Authorization: Bearer lm_VOTRE_TOKEN_ICI"
+```
+
+### 3.2 — Méthode édition manuelle
+
+Si vous préférez éditer directement le JSON, ajoutez le bloc suivant dans `~/.claude.json` (scope `user`, sous la clé `mcpServers` au premier niveau) :
+
+```json
+{
+  "mcpServers": {
+    "live-memory": {
+      "type": "http",
+      "url": "https://votre-serveur/mcp",
+      "headers": {
+        "Authorization": "Bearer lm_VOTRE_TOKEN_ICI"
+      }
+    }
+  }
+}
+```
+
+> **Remplacez** `lm_VOTRE_TOKEN_ICI` par le token obtenu à l'étape 2 et `votre-serveur` par votre domaine (ou `localhost:8080` en local).
+
+Pour le scope `project` (configuration partagée en équipe), créez plutôt un fichier `.mcp.json` à la racine du projet avec le même format.
+
+### 3.3 — Vérifier la connexion
+
+Après configuration :
+
+```bash
+claude mcp list
+```
+
+Vous devriez voir `live-memory` avec un statut connecté. Lancez ensuite Claude Code dans un projet et demandez :
+
+> *« Appelle `system_health` sur live-memory et donne-moi le retour. »*
+
+Si Claude répond avec `{"status": "ok", ...}`, la connexion fonctionne.
+
+### 3.4 — Whitelister les outils (éviter les prompts de permission)
+
+Claude Code demande confirmation à chaque appel d'outil MCP non autorisé. Pour éviter ces interruptions, ajoutez les outils Live Memory à la liste blanche du projet (ou de l'utilisateur).
+
+Créez ou éditez `.claude/settings.local.json` à la racine du projet :
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__live-memory__space_list",
+      "mcp__live-memory__space_info",
+      "mcp__live-memory__space_rules",
+      "mcp__live-memory__bank_read_all",
+      "mcp__live-memory__bank_read",
+      "mcp__live-memory__live_read",
+      "mcp__live-memory__live_note",
+      "mcp__live-memory__live_search",
+      "mcp__live-memory__bank_consolidate",
+      "mcp__live-memory__system_health"
+    ]
+  }
+}
+```
+
+> 💡 **Convention de nommage** : Claude Code expose chaque outil MCP sous la forme `mcp__<nom-du-serveur>__<nom-de-l-outil>`. Si vous avez nommé votre serveur `live-memory-prod` à l'étape 3.1, remplacez le préfixe en conséquence.
+
+Alternative interactive : tapez `/permissions` dans une session Claude Code pour ouvrir l'éditeur de permissions.
+
+Pour une configuration globale (tous projets), utilisez plutôt `~/.claude/settings.json`.
+
+### 3.5 — Serveur distant HTTPS
+
+Pour un déploiement production, l'URL et le bloc JSON sont identiques — seul le schéma change (`https://` au lieu de `http://`). Aucune option supplémentaire n'est nécessaire côté Claude Code.
+
+---
+
+## 📁 Étape 4 — Créer un espace mémoire
+
+Avant que Claude Code puisse écrire des notes, il faut un **espace mémoire** avec des **rules** qui définissent la structure de la Memory Bank.
+
+### Via la CLI
+
+```bash
+python scripts/mcp_cli.py space create mon-projet \
+  --rules-file ./RULES/standard.memory.bank.md \
+  -d "Mon projet de développement"
+```
+
+Plusieurs templates de rules sont fournis dans le répertoire `RULES/` du repo :
+
+| Template                              | Usage                                                       |
+| ------------------------------------- | ----------------------------------------------------------- |
+| `RULES/standard.memory.bank.md`       | Memory Bank Cline classique (6 fichiers projet)             |
+| `RULES/product.management.memory.bank.md` | Équipe produit (vision, portfolio, personas, features)  |
+| `RULES/medical.memory.bank.md`        | Suivi de patient / dossier clinique                         |
+| `RULES/presales.memory.bank.md`       | Avant-vente, qualification de prospect, RFP                 |
+| `RULES/book.memory.bank.md`           | Écriture de livre / projet éditorial                        |
+| `RULES/live-mem.standard.memory.bank.md` | Développement du serveur Live Memory lui-même            |
+
+### Via Claude Code directement
+
+Vous pouvez aussi demander à Claude de créer l'espace. Dites-lui simplement :
+
+> *« Utilise l'outil `space_create` pour créer un espace `mon-projet` avec des rules standard de type Memory Bank (projectbrief, activeContext, progress, techContext, systemPatterns, productContext). »*
+
+Claude Code utilisera l'outil MCP `space_create` pour le faire.
+
+### Exemple de rules standard
+
+```markdown
+# Memory Bank Rules
+
+## Fichiers à maintenir
+
+### projectbrief.md
+Vision, objectifs, périmètre du projet.
+
+### activeContext.md
+Focus actuel, travail en cours, décisions récentes, prochaines étapes.
+
+### progress.md
+Ce qui fonctionne, ce qui reste à faire, problèmes connus.
+
+### techContext.md
+Technologies utilisées, configuration, contraintes techniques.
+
+### systemPatterns.md
+Architecture, patterns, décisions techniques, composants.
+
+### productContext.md
+Pourquoi ce projet existe, problèmes résolus, expérience utilisateur.
+```
+
+---
+
+## 📝 Étape 5 — Donner des instructions à Claude Code
+
+Claude Code lit automatiquement les fichiers `CLAUDE.md` au démarrage. Deux emplacements possibles :
+
+| Emplacement             | Portée                                                | Recommandé pour                       |
+| ----------------------- | ----------------------------------------------------- | ------------------------------------- |
+| `<racine-projet>/CLAUDE.md` | Le projet courant (commité avec le repo)          | Workflow spécifique au projet         |
+| `~/.claude/CLAUDE.md`   | Tous les projets de l'utilisateur (privé, non commité) | Préférences globales, identité, style |
+
+Pour Live Memory, le `CLAUDE.md` projet est l'endroit idéal car la valeur de `{SPACE}` est spécifique au projet.
+
+### Template recommandé (à coller dans `CLAUDE.md`)
+
+Ce template utilise le placeholder `{SPACE}` — il suffit de configurer **une seule valeur** :
+
+```markdown
+# Memory Bank — Live Memory MCP
+
+Ma mémoire se réinitialise complètement entre les sessions. Je dépends ENTIÈREMENT de la Memory Bank pour comprendre le projet et continuer efficacement.
+
+## 🔌 Configuration (à modifier par projet)
+
+Ma mémoire persistante est gérée par le serveur MCP **Live Memory** (`live-memory`).
+
+> **⚙️ La seule valeur à personnaliser :**
+>
+> - **SPACE** = `mon-projet`       ← Remplacez par votre space_id
+>
+> Toutes les instructions ci-dessous utilisent `{SPACE}` — je le substitue automatiquement par la valeur ci-dessus.
+> Le nom de l'agent est **auto-détecté** depuis le token d'authentification (pas besoin de le configurer).
+
+## 📖 Au démarrage de CHAQUE tâche (OBLIGATOIRE)
+
+1. Appeler `space_rules("{SPACE}")` pour lire les rules (structure de la bank)
+2. Appeler `bank_read_all("{SPACE}")` pour charger TOUT le contexte consolidé
+3. Appeler `live_read(space_id="{SPACE}")` pour lire les **notes non consolidées**
+4. Lire attentivement le contenu avant de commencer
+5. Identifier le focus actuel dans `activeContext.md`
+
+> ⚠️ Ne JAMAIS commencer à travailler sans avoir lu la bank.
+>
+> 💡 **Pourquoi lire les notes live ?** Entre deux sessions, des notes ont pu être écrites (par moi ou par d'autres agents) sans avoir été consolidées dans la bank. Ces notes contiennent du contexte récent qui n'apparaît pas encore dans les fichiers bank. Les ignorer = risquer de refaire du travail déjà fait ou de rater des décisions récentes.
+
+## 📝 Pendant le travail
+
+Écrire des notes fréquentes et atomiques avec `live_note` :
+
+    live_note(space_id="{SPACE}", category="<catégorie>", content="...")
+
+Le paramètre `agent` est **auto-détecté** depuis le token — inutile de le passer.
+
+**Catégories** :
+- `observation` — Constats factuels, résultats de commandes
+- `decision` — Choix techniques et leur justification
+- `progress` — Avancement, ce qui est terminé
+- `issue` — Problèmes rencontrés, bugs
+- `todo` — Tâches identifiées à faire
+- `insight` — Apprentissages, patterns découverts
+- `question` — Points à clarifier, décisions en suspens
+
+## 🧠 En fin de session (ou après un bloc de travail significatif)
+
+    bank_consolidate(space_id="{SPACE}")
+
+Le LLM consolidera **mes propres notes** (auto-détection de l'agent depuis le token) en mettant à jour les fichiers de la bank selon les rules du space.
+
+> ℹ️ Seul un admin peut consolider les notes de tous les agents (`agent=""`).
+
+## ⚠️ Règles impératives
+
+1. **Ne JAMAIS écrire directement dans la bank** — seule la consolidation LLM le fait
+2. **Toujours passer `space_id="{SPACE}"`** dans tous les appels
+3. **Écrire des notes atomiques après chaque étape importante** — 1 note = 1 fait, 1 décision, ou 1 tâche
+4. **Consolider en fin de session** — ne jamais quitter sans consolider mais toujours après avoir validé avec l'utilisateur
+5. **Lire la bank au démarrage** — ne jamais travailler sans contexte
+
+## 🔄 Quand demander une mise à jour
+
+Si l'utilisateur demande **"update memory bank"** ou **"met à jour la memory bank"** :
+1. Écrire des notes `live_note` résumant l'état actuel du travail
+2. Appeler `bank_consolidate(space_id="{SPACE}")`
+3. Vérifier le résultat avec `bank_read_all("{SPACE}")`
+
+## 📊 Commandes utiles
+
+| Action                          | Commande                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------- |
+| Lire tout le contexte           | `bank_read_all("{SPACE}")`                                                |
+| Lire les rules                  | `space_rules("{SPACE}")`                                                  |
+| Écrire une note                 | `live_note(space_id="{SPACE}", category="...", content="...")`            |
+| Consolider                      | `bank_consolidate(space_id="{SPACE}")`                                    |
+| Voir les notes récentes         | `live_read(space_id="{SPACE}")`                                           |
+| Voir les notes d'un autre agent | `live_read(space_id="{SPACE}", agent="autre-agent")`                      |
+| Info sur l'espace               | `space_info("{SPACE}")`                                                   |
+```
+
+> 💡 **Pour un nouveau projet** : copiez ce fichier dans `<racine-projet>/CLAUDE.md`, changez la ligne `SPACE`, c'est tout !
+
+### Version minimaliste (`~/.claude/CLAUDE.md` global)
+
+Si vous préférez ne pas commiter d'instructions Live Memory dans chaque projet, ajoutez ce bloc court dans `~/.claude/CLAUDE.md` :
+
+```
+Tu as accès à Live Memory (serveur MCP "live-memory").
+- Au démarrage: space_rules("{SPACE}"), bank_read_all("{SPACE}"), live_read("{SPACE}")
+- Pendant le travail: live_note(space_id="{SPACE}", category="...", content="...")
+- En fin de session: bank_consolidate(space_id="{SPACE}")
+Le `{SPACE}` est défini dans le CLAUDE.md du projet courant. L'agent est auto-détecté depuis le token.
+```
+
+Chaque projet déclare ensuite uniquement sa valeur de `{SPACE}` dans son propre `CLAUDE.md`.
+
+---
+
+## 🔄 Workflow recommandé
+
+### Workflow type d'une session de développement
+
+```
+┌────────────────────────────────────────────────┐
+│  1. DÉMARRAGE                                  │
+│     space_rules("mon-projet")                  │
+│     bank_read_all("mon-projet")                │
+│     live_read("mon-projet")                    │
+│     → Claude lit rules + bank + notes live     │
+├────────────────────────────────────────────────┤
+│  2. TRAVAIL (boucle)                           │
+│     • Claude code, analyse, répond             │
+│     • live_note("observation", "Build OK")     │
+│     • live_note("decision", "On part sur X")   │
+│     • live_note("todo", "Tests à écrire")      │
+│     • live_note("progress", "Auth terminée")   │
+├────────────────────────────────────────────────┤
+│  3. FIN DE SESSION                             │
+│     bank_consolidate("mon-projet")             │
+│     → LLM synthétise les notes en bank         │
+│     → Notes live supprimées après succès       │
+└────────────────────────────────────────────────┘
+```
+
+### Fréquence de consolidation
+
+| Situation                   | Recommandation                       |
+| --------------------------- | ------------------------------------ |
+| Session courte (< 10 notes) | Consolider en fin de session         |
+| Session longue (> 20 notes) | Consolider toutes les 15-20 notes    |
+| Changement de contexte      | Consolider avant de changer de sujet |
+| Fin de journée              | Toujours consolider                  |
+
+### Visualiser en temps réel
+
+Pendant que Claude Code travaille, ouvrez l'interface web pour suivre en direct :
+
+```
+http://localhost:8080/live
+```
+
+Vous verrez les notes apparaître en temps réel dans la **Live Timeline** et la **Bank** se mettre à jour après chaque consolidation.
+
+---
+
+## 👥 Multi-agents : Claude Code + Cline + Claude Desktop + autres
+
+Live Memory permet à **plusieurs agents** de collaborer sur le même espace mémoire.
+
+### Scénario : Claude Code (dev) + Cline (review) + Claude Desktop (synthèse)
+
+Pour que plusieurs agents collaborent, il suffit de leur créer **un token par identité** :
+
+1. `admin_create_token name="claude-code-dev"`
+2. `admin_create_token name="cline-review"`
+3. `admin_create_token name="claude-desktop-synthese"`
+4. Configurer chaque agent avec son propre token
+
+L'identité de l'agent est **automatiquement déduite de son token** à chaque fois qu'il appelle `live_note` ou `bank_consolidate`. Aucun paramètre `agent` à préciser.
+
+### Communication entre agents
+
+Les agents ne se parlent pas directement. Ils communiquent **via l'espace partagé** :
+
+```
+Claude Code   → live_note(category="question", content="Faut-il supporter le CSV ?")
+Cline         → live_read(category="question")   ← voit la question
+Cline         → live_note(category="decision", content="Non, JSON uniquement")
+Claude Code   → live_read(category="decision")   ← voit la réponse
+```
+
+### Consolidation par agent
+
+Chaque agent consolide **ses propres notes** sans interférer avec celles des autres. Si un agent a les droits **admin**, il peut consolider les notes de tous les agents en appelant `bank_consolidate` (qui, pour un admin, traite par défaut tout le monde).
+
+---
+
+## 🔍 Dépannage
+
+### `claude mcp list` ne montre pas live-memory
+
+1. Vérifiez que le serveur est démarré : `curl http://localhost:8080/health`
+2. Vérifiez la syntaxe JSON dans `~/.claude.json` (pas de virgule trailing, accolades bien fermées)
+3. Quittez complètement Claude Code et relancez-le — le fichier n'est lu qu'au démarrage
+4. Inspectez les logs : `claude --debug` puis exécutez une session courte
+
+### Erreur "401 Unauthorized"
+
+- Le token est incorrect, périmé ou révoqué
+- Vérifiez que le header est bien `"Authorization": "Bearer lm_..."` (avec le préfixe `lm_`)
+- Attention aux espaces / sauts de ligne parasites lors du copier-coller du token
+- La bootstrap key fonctionne pour les tests mais créez un vrai token pour l'usage courant
+
+### Erreur "Accès refusé à l'espace"
+
+Le token est restreint à certains espaces (`space_ids`). Soit :
+- Créez un token sans restriction d'espace (paramètre `space_ids` vide)
+- Soit ajoutez l'espace au token : `admin_update_token(token_hash, space_ids="mon-projet", action="add")`
+
+### Claude Code demande la permission à chaque appel
+
+Whitelistez les outils via `.claude/settings.local.json` (voir Étape 3.4) ou tapez `/permissions` dans la session pour les ajouter interactivement.
+
+### Claude Code n'utilise pas Live Memory spontanément
+
+Sans `CLAUDE.md` explicite, Claude Code ne sait pas qu'il doit appeler ces outils en début de session. Ajoutez le template de l'Étape 5 dans `<racine-projet>/CLAUDE.md` ou `~/.claude/CLAUDE.md`.
+
+### Le MCP ne se connecte pas derrière un VPN ou un proxy
+
+Si Live Memory est sur un serveur distant, vérifiez :
+- Que le port 443 (HTTPS) ou 8080 (HTTP) est accessible
+- Que l'URL dans la config Claude Code est correcte (avec `/mcp` à la fin)
+- Testez manuellement : `curl -H "Authorization: Bearer lm_..." https://votre-serveur/mcp`
+
+### Suivre l'avancement d'une consolidation
+
+Côté serveur, observez les logs :
+
+```bash
+docker compose logs -f live-mem-service --tail 20
+```
+
+Claude Code maintient la connexion HTTP ouverte pendant tout l'appel, donc une consolidation longue ne pose normalement pas de problème de timeout côté client.
+
+---
+
+## 🖥️ Avec Claude Desktop
+
+La configuration est similaire à Claude Code mais le fichier change. Éditez `claude_desktop_config.json` :
+
+| OS          | Emplacement                                                       |
+| ----------- | ----------------------------------------------------------------- |
+| **macOS**   | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| **Windows** | `%APPDATA%\Claude\claude_desktop_config.json`                     |
+| **Linux**   | `~/.config/Claude/claude_desktop_config.json`                     |
+
+```json
+{
+  "mcpServers": {
+    "live-memory": {
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "Authorization": "Bearer lm_VOTRE_TOKEN_ICI"
+      },
+      "timeout": 600
+    }
+  }
+}
+```
+
+> **⚠️ Pour Claude Desktop** : ajoutez `"timeout": 600` pour autoriser les consolidations longues. Claude Code n'a pas besoin de ce paramètre.
+
+Redémarrez Claude Desktop après la modification. Les outils Live Memory apparaîtront dans la liste des outils disponibles.
+
+> ℹ️ **Note** : Claude Desktop ne propose pas de système d'allow-list par outil (contrairement à Claude Code). Les permissions se gèrent au niveau de l'application elle-même.
+
+---
+
+## 📊 Récapitulatif
+
+| Étape     | Action                                                | Temps      |
+| --------- | ----------------------------------------------------- | ---------- |
+| 1         | Démarrer Live Memory (`docker compose up -d`)         | 1 min      |
+| 2         | Créer un token (`mcp_cli.py token create`)            | 30 sec     |
+| 3         | Configurer Claude Code (`claude mcp add`)             | 1 min      |
+| 3.4       | Whitelister les outils (`.claude/settings.local.json`) | 1 min      |
+| 4         | Créer un espace (`space_create`)                      | 30 sec     |
+| 5         | Ajouter le `CLAUDE.md` du projet                      | 2 min      |
+| **Total** | **Prêt à utiliser**                                   | **~6 min** |
+
+---
+
+*Guide d'intégration Live Memory ↔ Claude Code v1.0.0 — [Documentation complète](README.md)*

--- a/INTEGRATION_GUIDE_CLAUDE_CODE.en.md
+++ b/INTEGRATION_GUIDE_CLAUDE_CODE.en.md
@@ -1,0 +1,546 @@
+# 🔌 Live Memory Integration Guide for Claude Code
+
+> **Version**: 1.0.0 | **Date**: 2026-05-16
+
+This guide walks you through connecting **Claude Code** (Anthropic's CLI, or its IDE extension) to **Live Memory** to give it shared, persistent working memory.
+
+---
+
+## 📋 Table of Contents
+
+- [Prerequisites](#-prerequisites)
+- [Step 1 — Start Live Memory](#-step-1--start-live-memory)
+- [Step 2 — Create a token for Claude Code](#-step-2--create-a-token-for-claude-code)
+- [Step 3 — Connect Claude Code to Live Memory](#-step-3--connect-claude-code-to-live-memory)
+- [Step 4 — Create a memory space](#-step-4--create-a-memory-space)
+- [Step 5 — Give Claude Code its instructions](#-step-5--give-claude-code-its-instructions)
+- [Recommended Workflow](#-recommended-workflow)
+- [Multi-agent: Claude Code + Cline + Claude Desktop + others](#-multi-agent-claude-code--cline--claude-desktop--others)
+- [Troubleshooting](#-troubleshooting)
+- [With Claude Desktop](#-with-claude-desktop)
+- [Summary](#-summary)
+
+---
+
+## 📦 Prerequisites
+
+| Component            | Version            | Check                               |
+| -------------------- | ------------------ | ----------------------------------- |
+| **Docker**           | ≥ 24.0             | `docker --version`                  |
+| **Docker Compose**   | v2                 | `docker compose version`            |
+| **Claude Code**      | ≥ 2.1              | `claude --version`                  |
+| **Live Memory**      | Deployed & running | `curl http://localhost:8080/health` |
+
+> 💡 If Claude Code is not installed: `npm install -g @anthropic-ai/claude-code` (macOS/Linux/Windows) or use the dedicated installer — see Anthropic's official documentation. Claude Code provides the `claude` command in the terminal and ships IDE extensions (VS Code, JetBrains) that share the same configuration.
+
+---
+
+## 🚀 Step 1 — Start Live Memory
+
+If Live Memory is not yet running:
+
+```bash
+cd /path/to/live-memory
+cp .env.example .env
+# Edit .env with your S3 credentials, LLMaaS settings, and ADMIN_BOOTSTRAP_KEY
+docker compose build
+docker compose up -d
+```
+
+**Check**:
+
+```bash
+# Should return {"status": "ok", ...}
+curl -s http://localhost:8080/health | jq .
+```
+
+---
+
+## 🔑 Step 2 — Create a token for Claude Code
+
+Claude Code needs a **Bearer Token** with `read,write` permissions to read and write the memory.
+
+### Option A — Via the CLI
+
+```bash
+cd /path/to/live-memory
+export MCP_TOKEN=<your_ADMIN_BOOTSTRAP_KEY>
+
+# Create a "read,write" token for Claude Code
+python scripts/mcp_cli.py token create claude-code-agent read,write
+```
+
+The CLI will print something like:
+
+```
+Token created successfully!
+  Name   : claude-code-agent
+  Token  : lm_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9T0u1V2
+  Perms  : read, write
+
+⚠️  This token will NEVER be displayed again. Copy it now!
+```
+
+> **⚠️ IMPORTANT**: Copy this token immediately! It will never be shown again (only the SHA-256 hash is stored).
+
+### Option B — Via the bootstrap key (temporary)
+
+For a quick test, you can use the `ADMIN_BOOTSTRAP_KEY` defined in your `.env` directly. But **in production**, always create a dedicated token with minimal permissions.
+
+---
+
+## ⚙️ Step 3 — Connect Claude Code to Live Memory
+
+Claude Code stores its MCP configuration in a JSON file. Three scopes are available:
+
+| Scope     | Location                                       | Reach                              |
+| --------- | ---------------------------------------------- | ---------------------------------- |
+| `local`   | `~/.claude.json` (key `projects.<cwd>`)        | Current directory only             |
+| `user`    | `~/.claude.json` (top-level `mcpServers` key)  | All projects of the current user   |
+| `project` | `.mcp.json` at the project root                | Committed to the repo (teams)      |
+
+For personal multi-project use, the `user` scope is usually the most convenient.
+
+### 3.1 — CLI method (recommended)
+
+```bash
+claude mcp add \
+  --transport http \
+  --scope user \
+  live-memory \
+  https://your-server/mcp \
+  --header "Authorization: Bearer lm_YOUR_TOKEN_HERE"
+```
+
+For a local server over HTTP:
+
+```bash
+claude mcp add \
+  --transport http \
+  --scope user \
+  live-memory \
+  http://localhost:8080/mcp \
+  --header "Authorization: Bearer lm_YOUR_TOKEN_HERE"
+```
+
+### 3.2 — Manual edit
+
+If you prefer editing the JSON directly, add the following block to `~/.claude.json` (`user` scope, under the top-level `mcpServers` key):
+
+```json
+{
+  "mcpServers": {
+    "live-memory": {
+      "type": "http",
+      "url": "https://your-server/mcp",
+      "headers": {
+        "Authorization": "Bearer lm_YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+> **Replace** `lm_YOUR_TOKEN_HERE` with the token from Step 2 and `your-server` with your domain (or `localhost:8080` locally).
+
+For the `project` scope (config shared across the team), create a `.mcp.json` file at the project root with the same format.
+
+### 3.3 — Verify the connection
+
+After configuration:
+
+```bash
+claude mcp list
+```
+
+You should see `live-memory` with a connected status. Then launch Claude Code in a project and ask:
+
+> *"Call `system_health` on live-memory and show me the response."*
+
+If Claude replies with `{"status": "ok", ...}`, the connection works.
+
+### 3.4 — Whitelist the tools (avoid permission prompts)
+
+Claude Code asks for confirmation on every unauthorized MCP tool call. To avoid these interruptions, add the Live Memory tools to the project (or user) allow-list.
+
+Create or edit `.claude/settings.local.json` at the project root:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__live-memory__space_list",
+      "mcp__live-memory__space_info",
+      "mcp__live-memory__space_rules",
+      "mcp__live-memory__bank_read_all",
+      "mcp__live-memory__bank_read",
+      "mcp__live-memory__live_read",
+      "mcp__live-memory__live_note",
+      "mcp__live-memory__live_search",
+      "mcp__live-memory__bank_consolidate",
+      "mcp__live-memory__system_health"
+    ]
+  }
+}
+```
+
+> 💡 **Naming convention**: Claude Code exposes each MCP tool as `mcp__<server-name>__<tool-name>`. If you named your server `live-memory-prod` in Step 3.1, adjust the prefix accordingly.
+
+Interactive alternative: type `/permissions` in a Claude Code session to open the permissions editor.
+
+For a global configuration (all projects), use `~/.claude/settings.json` instead.
+
+### 3.5 — Remote HTTPS server
+
+For a production deployment, the URL and JSON block are identical — only the scheme changes (`https://` instead of `http://`). No additional option is required on the Claude Code side.
+
+---
+
+## 📁 Step 4 — Create a memory space
+
+Before Claude Code can write notes, you need a **memory space** with **rules** that define the Memory Bank structure.
+
+### Via the CLI
+
+```bash
+python scripts/mcp_cli.py space create my-project \
+  --rules-file ./RULES/standard.memory.bank.md \
+  -d "My development project"
+```
+
+Several rule templates are provided in the `RULES/` directory of the repo:
+
+| Template                                  | Use case                                              |
+| ----------------------------------------- | ----------------------------------------------------- |
+| `RULES/standard.memory.bank.md`           | Classic Cline Memory Bank (6 project files)           |
+| `RULES/product.management.memory.bank.md` | Product team (vision, portfolio, personas, features)  |
+| `RULES/medical.memory.bank.md`            | Patient follow-up / clinical file                     |
+| `RULES/presales.memory.bank.md`           | Pre-sales, prospect qualification, RFP                |
+| `RULES/book.memory.bank.md`               | Book writing / editorial project                      |
+| `RULES/live-mem.standard.memory.bank.md`  | Development of the Live Memory server itself          |
+
+### Through Claude Code directly
+
+You can also ask Claude to create the space. Just tell it:
+
+> *"Use the `space_create` tool to create a space called `my-project` with standard Memory Bank rules (projectbrief, activeContext, progress, techContext, systemPatterns, productContext)."*
+
+Claude Code will invoke the MCP `space_create` tool.
+
+### Example of standard rules
+
+```markdown
+# Memory Bank Rules
+
+## Files to maintain
+
+### projectbrief.md
+Vision, goals, project scope.
+
+### activeContext.md
+Current focus, ongoing work, recent decisions, next steps.
+
+### progress.md
+What works, what's left to do, known issues.
+
+### techContext.md
+Technologies used, configuration, technical constraints.
+
+### systemPatterns.md
+Architecture, patterns, technical decisions, components.
+
+### productContext.md
+Why this project exists, problems solved, user experience.
+```
+
+---
+
+## 📝 Step 5 — Give Claude Code its instructions
+
+Claude Code automatically reads `CLAUDE.md` files on startup. Two possible locations:
+
+| Location                  | Reach                                              | Recommended for                       |
+| ------------------------- | -------------------------------------------------- | ------------------------------------- |
+| `<project-root>/CLAUDE.md` | The current project (committed with the repo)     | Project-specific workflow             |
+| `~/.claude/CLAUDE.md`     | All projects of the current user (private)         | Global preferences, identity, style   |
+
+For Live Memory, the project-level `CLAUDE.md` is the ideal spot because `{SPACE}` is project-specific.
+
+### Recommended template (paste into `CLAUDE.md`)
+
+This template uses the `{SPACE}` placeholder — you only need to configure **one value**:
+
+```markdown
+# Memory Bank — Live Memory MCP
+
+My memory resets completely between sessions. I depend ENTIRELY on the Memory Bank to understand the project and continue effectively.
+
+## 🔌 Configuration (to customize per project)
+
+My persistent memory is managed by the **Live Memory** MCP server (`live-memory`).
+
+> **⚙️ The only value to customize:**
+>
+> - **SPACE** = `my-project`       ← Replace with your space_id
+>
+> All instructions below use `{SPACE}` — I substitute it automatically with the value above.
+> The agent name is **auto-detected** from the authentication token (no need to configure it).
+
+## 📖 At the start of EVERY task (MANDATORY)
+
+1. Call `space_rules("{SPACE}")` to read the rules (bank structure)
+2. Call `bank_read_all("{SPACE}")` to load ALL consolidated context
+3. Call `live_read(space_id="{SPACE}")` to read **unconsolidated notes**
+4. Read the content carefully before starting
+5. Identify the current focus in `activeContext.md`
+
+> ⚠️ NEVER start working without having read the bank.
+>
+> 💡 **Why read live notes?** Between sessions, notes may have been written (by me or other agents) without being consolidated yet. These notes contain recent context not yet reflected in the bank files. Ignoring them = risking redoing work already done or missing recent decisions.
+
+## 📝 During work
+
+Write frequent, atomic notes via `live_note`:
+
+    live_note(space_id="{SPACE}", category="<category>", content="...")
+
+The `agent` parameter is **auto-detected** from the token — no need to pass it.
+
+**Categories**:
+- `observation` — Factual findings, command results
+- `decision` — Technical choices and their rationale
+- `progress` — Advancement, completed work
+- `issue` — Problems encountered, bugs
+- `todo` — Identified tasks to do
+- `insight` — Learnings, discovered patterns
+- `question` — Points to clarify, pending decisions
+
+## 🧠 At session end (or after a significant work block)
+
+    bank_consolidate(space_id="{SPACE}")
+
+The LLM will consolidate **my own notes** (agent auto-detected from token) by updating the bank files according to the space rules.
+
+> ℹ️ Only an admin can consolidate notes from all agents (`agent=""`).
+
+## ⚠️ Strict rules
+
+1. **NEVER write directly into the bank** — only the LLM consolidation does that
+2. **Always pass `space_id="{SPACE}"`** in every call
+3. **Write atomic notes after each significant step** — 1 note = 1 fact, 1 decision, or 1 task
+4. **Consolidate at session end** — never quit without consolidating, but always after validating with the user
+5. **Read the bank at startup** — never work without context
+
+## 🔄 When to request an update
+
+If the user says **"update memory bank"**:
+1. Write `live_note` notes summarizing the current state of work
+2. Call `bank_consolidate(space_id="{SPACE}")`
+3. Verify the result with `bank_read_all("{SPACE}")`
+
+## 📊 Useful commands
+
+| Action                          | Command                                                                   |
+| ------------------------------- | ------------------------------------------------------------------------- |
+| Read full context               | `bank_read_all("{SPACE}")`                                                |
+| Read rules                      | `space_rules("{SPACE}")`                                                  |
+| Write a note                    | `live_note(space_id="{SPACE}", category="...", content="...")`            |
+| Consolidate                     | `bank_consolidate(space_id="{SPACE}")`                                    |
+| See recent notes                | `live_read(space_id="{SPACE}")`                                           |
+| See another agent's notes       | `live_read(space_id="{SPACE}", agent="other-agent")`                      |
+| Space info                      | `space_info("{SPACE}")`                                                   |
+```
+
+> 💡 **For a new project**: copy this file into `<project-root>/CLAUDE.md`, change the `SPACE` line, that's it!
+
+### Minimalist version (`~/.claude/CLAUDE.md` global)
+
+If you'd rather not commit Live Memory instructions in every project, add this short block to `~/.claude/CLAUDE.md`:
+
+```
+You have access to Live Memory (MCP server "live-memory").
+- At startup: space_rules("{SPACE}"), bank_read_all("{SPACE}"), live_read("{SPACE}")
+- During work: live_note(space_id="{SPACE}", category="...", content="...")
+- At session end: bank_consolidate(space_id="{SPACE}")
+`{SPACE}` is defined in the current project's CLAUDE.md. The agent is auto-detected from the token.
+```
+
+Each project then declares only its `{SPACE}` value in its own `CLAUDE.md`.
+
+---
+
+## 🔄 Recommended Workflow
+
+### Typical development session workflow
+
+```
+┌────────────────────────────────────────────────┐
+│  1. STARTUP                                    │
+│     space_rules("my-project")                  │
+│     bank_read_all("my-project")                │
+│     live_read("my-project")                    │
+│     → Claude reads rules + bank + live notes   │
+├────────────────────────────────────────────────┤
+│  2. WORK (loop)                                │
+│     • Claude codes, analyzes, replies          │
+│     • live_note("observation", "Build OK")     │
+│     • live_note("decision", "Going with X")    │
+│     • live_note("todo", "Tests to write")      │
+│     • live_note("progress", "Auth done")       │
+├────────────────────────────────────────────────┤
+│  3. SESSION END                                │
+│     bank_consolidate("my-project")             │
+│     → LLM synthesizes notes into the bank      │
+│     → Live notes deleted after success         │
+└────────────────────────────────────────────────┘
+```
+
+### Consolidation frequency
+
+| Situation                   | Recommendation                       |
+| --------------------------- | ------------------------------------ |
+| Short session (< 10 notes)  | Consolidate at session end           |
+| Long session (> 20 notes)   | Consolidate every 15–20 notes        |
+| Context switch              | Consolidate before switching topics  |
+| End of day                  | Always consolidate                   |
+
+### Real-time visualization
+
+While Claude Code works, open the web UI to watch live:
+
+```
+http://localhost:8080/live
+```
+
+Notes will appear in real time in the **Live Timeline**, and the **Bank** updates after each consolidation.
+
+---
+
+## 👥 Multi-agent: Claude Code + Cline + Claude Desktop + others
+
+Live Memory lets **multiple agents** collaborate on the same memory space.
+
+### Scenario: Claude Code (dev) + Cline (review) + Claude Desktop (synthesis)
+
+For several agents to collaborate, create **one token per identity**:
+
+1. `admin_create_token name="claude-code-dev"`
+2. `admin_create_token name="cline-review"`
+3. `admin_create_token name="claude-desktop-synth"`
+4. Configure each agent with its own token
+
+The agent's identity is **automatically derived from its token** every time it calls `live_note` or `bank_consolidate`. No `agent` parameter to pass.
+
+### Agent-to-agent communication
+
+Agents don't talk to each other directly. They communicate **through the shared space**:
+
+```
+Claude Code   → live_note(category="question", content="Should we support CSV?")
+Cline         → live_read(category="question")   ← sees the question
+Cline         → live_note(category="decision", content="No, JSON only")
+Claude Code   → live_read(category="decision")   ← sees the answer
+```
+
+### Per-agent consolidation
+
+Each agent consolidates **its own notes** without interfering with others'. If an agent has **admin** rights, it can consolidate notes from all agents by calling `bank_consolidate` (which, for an admin, defaults to processing everyone).
+
+---
+
+## 🔍 Troubleshooting
+
+### `claude mcp list` doesn't show live-memory
+
+1. Check the server is running: `curl http://localhost:8080/health`
+2. Check the JSON syntax in `~/.claude.json` (no trailing comma, braces closed)
+3. Fully quit Claude Code and relaunch — the file is read only at startup
+4. Inspect the logs: `claude --debug` then run a short session
+
+### "401 Unauthorized" error
+
+- Token is wrong, expired, or revoked
+- Make sure the header is `"Authorization": "Bearer lm_..."` (with the `lm_` prefix)
+- Watch for stray spaces/newlines when copy-pasting the token
+- The bootstrap key works for tests, but create a real token for normal use
+
+### "Access denied to space" error
+
+The token is restricted to certain spaces (`space_ids`). Either:
+- Create a token without space restriction (empty `space_ids` parameter)
+- Or add the space to the token: `admin_update_token(token_hash, space_ids="my-project", action="add")`
+
+### Claude Code prompts for permission on every call
+
+Whitelist the tools via `.claude/settings.local.json` (see Step 3.4), or type `/permissions` in the session to add them interactively.
+
+### Claude Code doesn't use Live Memory on its own
+
+Without an explicit `CLAUDE.md`, Claude Code doesn't know it should call these tools at the start of a session. Add the Step 5 template to `<project-root>/CLAUDE.md` or `~/.claude/CLAUDE.md`.
+
+### MCP won't connect behind a VPN or proxy
+
+If Live Memory is on a remote server, check that:
+- Port 443 (HTTPS) or 8080 (HTTP) is reachable
+- The URL in the Claude Code config is correct (with `/mcp` at the end)
+- Manual test: `curl -H "Authorization: Bearer lm_..." https://your-server/mcp`
+
+### Following a consolidation in progress
+
+Server-side, watch the logs:
+
+```bash
+docker compose logs -f live-mem-service --tail 20
+```
+
+Claude Code keeps the HTTP connection open for the entire call, so a long consolidation doesn't typically cause client-side timeout issues.
+
+---
+
+## 🖥️ With Claude Desktop
+
+Configuration is similar to Claude Code, but the file changes. Edit `claude_desktop_config.json`:
+
+| OS          | Location                                                          |
+| ----------- | ----------------------------------------------------------------- |
+| **macOS**   | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| **Windows** | `%APPDATA%\Claude\claude_desktop_config.json`                     |
+| **Linux**   | `~/.config/Claude/claude_desktop_config.json`                     |
+
+```json
+{
+  "mcpServers": {
+    "live-memory": {
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "Authorization": "Bearer lm_YOUR_TOKEN_HERE"
+      },
+      "timeout": 600
+    }
+  }
+}
+```
+
+> **⚠️ For Claude Desktop**: add `"timeout": 600` to allow long consolidations. Claude Code does not need this parameter.
+
+Restart Claude Desktop after the change. The Live Memory tools will appear in the available tools list.
+
+> ℹ️ **Note**: Claude Desktop does not provide a per-tool allow-list system (unlike Claude Code). Permissions are managed at the application level.
+
+---
+
+## 📊 Summary
+
+| Step      | Action                                                  | Time       |
+| --------- | ------------------------------------------------------- | ---------- |
+| 1         | Start Live Memory (`docker compose up -d`)              | 1 min      |
+| 2         | Create a token (`mcp_cli.py token create`)              | 30 sec     |
+| 3         | Configure Claude Code (`claude mcp add`)                | 1 min      |
+| 3.4       | Whitelist the tools (`.claude/settings.local.json`)     | 1 min      |
+| 4         | Create a space (`space_create`)                         | 30 sec     |
+| 5         | Add the project's `CLAUDE.md`                           | 2 min      |
+| **Total** | **Ready to use**                                        | **~6 min** |
+
+---
+
+*Live Memory ↔ Claude Code integration guide v1.0.0 — [Full documentation](README.en.md)*

--- a/INTEGRATION_GUIDE_CLINE.en.md
+++ b/INTEGRATION_GUIDE_CLINE.en.md
@@ -1,0 +1,501 @@
+# 🔌 Live Memory Integration Guide for Cline (VS Code / VSCodium)
+
+> **Version**: 1.2.0 | **Date**: 2026-03-27
+
+This guide walks you step by step through connecting **Cline** (the AI agent in VS Code or VSCodium) to **Live Memory** to give it shared, persistent working memory.
+
+---
+
+## 📋 Table of Contents
+
+- [Prerequisites](#-prerequisites)
+- [Step 1 — Start Live Memory](#-step-1--start-live-memory)
+- [Step 2 — Create a token for Cline](#-step-2--create-a-token-for-cline)
+- [Step 3 — Configure Cline in VS Code / VSCodium](#-step-3--configure-cline-in-vs-code--vscodium)
+- [Step 4 — Create a memory space](#-step-4--create-a-memory-space)
+- [Step 5 — Give Cline its instructions](#-step-5--give-cline-its-instructions)
+- [Recommended Workflow](#-recommended-workflow)
+- [Custom Instructions for Cline](#-custom-instructions-for-cline)
+- [Multi-agent: Cline + Claude + others](#-multi-agent-cline--claude--others)
+- [Troubleshooting](#-troubleshooting)
+- [With Claude Desktop](#-with-claude-desktop)
+
+---
+
+## 📦 Prerequisites
+
+| Component                   | Version            | Check                               |
+| --------------------------- | ------------------ | ----------------------------------- |
+| **Docker**                  | ≥ 24.0             | `docker --version`                  |
+| **Docker Compose**          | v2                 | `docker compose version`            |
+| **VS Code** or **VSCodium** | Recent             | —                                   |
+| **Cline extension**         | Recent             | Installed from the marketplace      |
+| **Live Memory**             | Deployed & running | `curl http://localhost:8080/health` |
+
+---
+
+## 🚀 Step 1 — Start Live Memory
+
+If Live Memory is not yet running:
+
+```bash
+cd /path/to/live-memory
+cp .env.example .env
+# Edit .env with your S3 credentials, LLMaaS settings, and ADMIN_BOOTSTRAP_KEY
+docker compose build
+docker compose up -d
+```
+
+**Check**:
+
+```bash
+# Should return {"status": "ok", ...}
+curl -s http://localhost:8080/health | jq .
+```
+
+---
+
+## 🔑 Step 2 — Create a token for Cline
+
+Cline needs a **Bearer Token** with `read,write` permissions to read and write the memory.
+
+### Option A — Via the CLI
+
+```bash
+cd /path/to/live-memory
+export MCP_TOKEN=<your_ADMIN_BOOTSTRAP_KEY>
+
+# Create a "write" token for Cline
+python scripts/mcp_cli.py token create cline-agent read,write
+```
+
+The CLI will print something like:
+
+```
+Token created successfully!
+  Name   : cline-agent
+  Token  : lm_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9T0u1V2
+  Perms  : read, write
+
+⚠️  This token will NEVER be displayed again. Copy it now!
+```
+
+> **⚠️ IMPORTANT**: Copy this token immediately! It will never be shown again (only the SHA-256 hash is stored).
+
+### Option B — Via the bootstrap key (temporary)
+
+For a quick test, you can use the `ADMIN_BOOTSTRAP_KEY` defined in your `.env` directly. But **in production**, always create a dedicated token with minimal permissions.
+
+---
+
+## ⚙️ Step 3 — Configure Cline in VS Code / VSCodium
+
+### 3.1 Open Cline's MCP settings
+
+1. Open VS Code / VSCodium
+2. Open the Cline panel (Cline icon in the sidebar)
+3. Click the **⚙️ Settings** gear icon at the top of the Cline panel
+4. Find **"MCP Servers"** or click the **MCP** tab
+5. Click **"Edit MCP Settings"** (or the button to edit the JSON)
+
+### 3.2 Add Live Memory as an MCP server
+
+In the `cline_mcp_settings.json` file that opens, add the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "live-memory": {
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "Authorization": "Bearer lm_YOUR_TOKEN_HERE"
+      },
+      "timeout": 600
+    }
+  }
+}
+```
+
+> **Replace** `lm_YOUR_TOKEN_HERE` with the token from Step 2.
+> **⚠️ The `timeout` parameter is critical**: LLM consolidation can take longer than 60 seconds (Cline's default timeout). Raising it to 600 seconds is mandatory, in line with your `.env` configuration.
+
+### 3.3 Where is the config file located?
+
+| OS                 | Typical location                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| **macOS**          | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`     |
+| **Linux**          | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`                         |
+| **VSCodium macOS** | `~/Library/Application Support/VSCodium/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
+| **VSCodium Linux** | `~/.config/VSCodium/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`                     |
+
+### 3.4 Verify the connection
+
+After saving the config file:
+
+1. **Restart Cline** (or reload VS Code with `Ctrl+Shift+P` → "Developer: Reload Window")
+2. In the Cline panel, click the **MCP** tab
+3. You should see **"live-memory"** with a green indicator ✅
+4. Click it to view the **38 available tools**
+
+### 3.5 Remote server (production)
+
+If Live Memory is deployed on an HTTPS server:
+
+```json
+{
+  "mcpServers": {
+    "live-memory": {
+      "url": "https://live-mem.your-domain.com/mcp",
+      "headers": {
+        "Authorization": "Bearer lm_YOUR_TOKEN_HERE"
+      },
+      "timeout": 600
+    }
+  }
+}
+```
+
+---
+
+## 📁 Step 4 — Create a memory space
+
+Before Cline can write notes, you need a **memory space** with **rules** that define the Memory Bank structure.
+
+### Via the CLI
+
+```bash
+python scripts/mcp_cli.py space create my-project \
+  --rules-file ./rules/standard.md \
+  -d "My development project"
+```
+
+### Through Cline directly
+
+You can also ask Cline to create the space. Just tell it:
+
+> *"Use the `space_create` tool to create a space called `my-project` with standard Memory Bank rules (projectbrief, activeContext, progress, techContext, systemPatterns, productContext)."*
+
+Cline will invoke the MCP `space_create` tool.
+
+### Example of standard rules
+
+```markdown
+# Memory Bank Rules
+
+## Files to maintain
+
+### projectbrief.md
+Vision, goals, project scope.
+
+### activeContext.md
+Current focus, ongoing work, recent decisions, next steps.
+
+### progress.md
+What works, what's left to do, known issues.
+
+### techContext.md
+Technologies used, configuration, technical constraints.
+
+### systemPatterns.md
+Architecture, patterns, technical decisions, components.
+
+### productContext.md
+Why this project exists, problems solved, user experience.
+```
+
+---
+
+## 📝 Step 5 — Give Cline its instructions
+
+To make Cline use Live Memory automatically, add **Custom Instructions** to its settings.
+
+### 5.1 Where to configure Custom Instructions
+
+In Cline: **Settings** → **Custom Instructions** (or in your project's `.clinerules` file).
+
+### 5.2 Recommended instructions (template `{SPACE}`)
+
+Copy the content below into your agent's **Custom Instructions** (or into a `.clinerules` file at your project root). This template uses the `{SPACE}` placeholder — only **one value** needs to be configured:
+
+
+```markdown
+# Cline's Memory Bank — Live Memory MCP
+
+My memory resets completely between sessions. I depend ENTIRELY on the Memory Bank to understand the project and continue effectively.
+
+## 🔌 Configuration (to customize per project)
+
+My persistent memory is managed by the **Live Memory** MCP server (`my-live-mem`).
+
+> **⚙️ The only value to customize:**
+>
+> - **SPACE** = `my-project`       ← Replace with your space_id
+>
+> All instructions below use `{SPACE}` — I substitute it automatically with the value above.
+> The agent name is **auto-detected** from the authentication token (no need to configure it).
+
+## 📖 At the start of EVERY task (MANDATORY)
+
+1. Call `space_rules("{SPACE}")` to read the rules (bank structure)
+2. Call `bank_read_all("{SPACE}")` to load ALL consolidated context
+3. Call `live_read(space_id="{SPACE}")` to read **unconsolidated notes**
+4. Read the content carefully before starting
+5. Identify the current focus in `activeContext.md`
+
+> ⚠️ NEVER start working without having read the bank.
+>
+> 💡 **Why read live notes?** Between sessions, notes may have been written (by me or other agents) without being consolidated yet. These notes contain recent context not yet reflected in the bank files. Ignoring them = risking redoing work already done or missing recent decisions.
+
+## 📝 During work
+
+Write frequent, atomic notes via `live_note`:
+
+live_note(space_id="{SPACE}", category="<category>", content="...")
+
+The `agent` parameter is **auto-detected** from the token — no need to pass it.
+
+**Categories**:
+- `observation` — Factual findings, command results
+- `decision` — Technical choices and their rationale
+- `progress` — Advancement, completed work
+- `issue` — Problems encountered, bugs
+- `todo` — Identified tasks to do
+- `insight` — Learnings, discovered patterns
+- `question` — Points to clarify, pending decisions
+
+## 🧠 At session end (or after a significant work block)
+
+bank_consolidate(space_id="{SPACE}")
+
+The LLM will consolidate **my own notes** (agent auto-detected from token) by updating the bank files according to the space rules.
+
+> ℹ️ Only an admin can consolidate notes from all agents (`agent=""`).
+
+## ⚠️ Strict rules
+
+1. **NEVER write directly into the bank** — only the LLM consolidation does that
+2. **Always pass `space_id="{SPACE}"`** in every call
+3. **Write atomic notes after each significant step** — 1 note = 1 fact, 1 decision, or 1 task
+4. **Consolidate at session end** — never quit without consolidating, but always after validating with the user
+5. **Read the bank at startup** — never work without context
+
+## 🔄 When to request an update
+
+If the user says **"update memory bank"**:
+1. Write `live_note` notes summarizing the current state of work
+2. Call `bank_consolidate(space_id="{SPACE}")`
+3. Verify the result with `bank_read_all("{SPACE}")`
+
+## 📊 Useful commands
+
+| Action                          | Command                                                                   |
+| ------------------------------- | ------------------------------------------------------------------------- |
+| Read full context               | `bank_read_all("{SPACE}")`                                                |
+| Read rules                      | `space_rules("{SPACE}")`                                                  |
+| Write a note                    | `live_note(space_id="{SPACE}", category="...", content="...")`            |
+| Consolidate                     | `bank_consolidate(space_id="{SPACE}")`                                    |
+| See recent notes                | `live_read(space_id="{SPACE}")`                                           |
+| See another agent's notes       | `live_read(space_id="{SPACE}", agent="other-agent")`                      |
+| Space info                      | `space_info("{SPACE}")`                                                   |
+```
+
+> 💡 **For a new project**: copy this file, change the `SPACE` line, that's it!
+
+---
+
+## 🔄 Recommended Workflow
+
+### Typical development session workflow
+
+```
+┌────────────────────────────────────────────────┐
+│  1. STARTUP                                    │
+│     space_rules("my-project")                  │
+│     bank_read_all("my-project")                │
+│     live_read("my-project")                    │
+│     → Cline reads rules + bank + live notes    │
+├────────────────────────────────────────────────┤
+│  2. WORK (loop)                                │
+│     • Cline codes, analyzes, replies           │
+│     • live_note("observation", "Build OK")     │
+│     • live_note("decision", "Going with X")    │
+│     • live_note("todo", "Tests to write")      │
+│     • live_note("progress", "Auth done")       │
+├────────────────────────────────────────────────┤
+│  3. SESSION END                                │
+│     bank_consolidate("my-project")             │
+│     → LLM synthesizes notes into the bank      │
+│     → Live notes deleted after success         │
+└────────────────────────────────────────────────┘
+```
+
+### Consolidation frequency
+
+| Situation                   | Recommendation                       |
+| --------------------------- | ------------------------------------ |
+| Short session (< 10 notes)  | Consolidate at session end           |
+| Long session (> 20 notes)   | Consolidate every 15–20 notes        |
+| Context switch              | Consolidate before switching topics  |
+| End of day                  | Always consolidate                   |
+
+### Real-time visualization
+
+While Cline works, open the web UI to watch live:
+
+```
+http://localhost:8080/live
+```
+
+Notes will appear in real time in the **Live Timeline**, and the **Bank** updates after each consolidation.
+
+---
+
+## 📋 Custom Instructions for Cline
+
+### Template version (recommended)
+
+Copy the contents of the [`.clinerules/standard.memory.bank.md`](.clinerules/standard.memory.bank.md) file into your Custom Instructions or into a `.clinerules` file at your project root.
+
+Then modify **only the `{SPACE}` value** to match your project. The agent name is auto-detected.
+
+### Minimalist version (copy-paste into Custom Instructions)
+
+If you want an ultra-short version, add this to global Custom Instructions:
+
+```
+You have access to Live Memory (MCP server).
+- At startup: space_rules("{SPACE}"), bank_read_all("{SPACE}"), live_read("{SPACE}")
+- During work: live_note(space_id="{SPACE}", category="...", content="...")
+- At session end: bank_consolidate(space_id="{SPACE}")
+Where {SPACE} = "my-project". The agent is auto-detected from the token.
+```
+
+---
+
+## 👥 Multi-agent: Cline + Claude + others
+
+Live Memory lets **multiple agents** collaborate on the same memory space.
+
+### Scenario: Cline (dev) + Claude (review)
+
+For two agents to collaborate, just create **two different tokens**:
+
+1. Create the token for Cline (`admin_create_token name="cline-dev"`)
+2. Create the token for Claude (`admin_create_token name="claude-review"`)
+3. Configure each agent with its own token
+
+The agent's identity is **automatically derived from its token** every time it calls `live_note` or `bank_consolidate`. They don't need to specify it.
+
+### Agent-to-agent communication
+
+Agents don't talk to each other directly. They communicate **through the shared space**:
+
+```
+Cline  → live_note(category="question", content="Should we support CSV?")
+Claude → live_read(category="question")  ← sees Cline's question
+Claude → live_note(category="decision", content="No, JSON only")
+Cline  → live_read(category="decision")  ← sees Claude's answer
+```
+
+### Per-agent consolidation
+
+Each agent consolidates **its own notes** without interfering with the others':
+
+```
+Cline  → bank_consolidate(space_id="my-project")  # Only consolidates cline-dev's notes
+Claude → bank_consolidate(space_id="my-project")  # Only consolidates claude-review's notes
+```
+
+If an agent has **admin** rights, it can consolidate everyone's notes by calling `bank_consolidate` (which, for an admin, defaults to processing everyone).
+
+---
+
+## 🔍 Troubleshooting
+
+### Cline doesn't see Live Memory tools
+
+1. Check the server is running: `curl http://localhost:8080/health`
+2. Check the JSON syntax in `cline_mcp_settings.json` (no trailing comma)
+3. Reload VS Code (`Ctrl+Shift+P` → "Developer: Reload Window")
+4. In Cline's MCP tab, check whether `live-memory` appears in red (connection error)
+
+### "401 Unauthorized" error
+
+- Token is wrong or revoked
+- Make sure the header is `"Authorization": "Bearer lm_..."` (with the `lm_` prefix)
+- The bootstrap key works for tests, but create a real token for normal use
+
+### "Access denied to space" error
+
+The token is restricted to certain spaces (`space_ids`). Either:
+- Create a token without space restriction (empty `space_ids` parameter)
+- Or add the space to the token: `admin_update_token(token_hash, space_ids="my-project", action="add")`
+
+### Cline doesn't use Live Memory on its own
+
+Add explicit **Custom Instructions** (see [Step 5](#-step-5--give-cline-its-instructions)). Without instructions, Cline doesn't know it should use these tools.
+
+### Timeout error / Consolidation fails after 60 seconds
+
+By default, Cline and Claude Desktop interrupt MCP requests after 60 seconds, which is often too short for a consolidation (the LLM can take several minutes).
+
+1. Make sure you added `"timeout": 600` in your agent's MCP configuration, in line with the server timeout set in your `.env`.
+2. You can follow the actual progress server-side in the logs:
+
+```bash
+docker compose logs -f live-mem-service --tail 20
+```
+
+### MCP won't connect behind a VPN
+
+If Live Memory is on a remote server, check that:
+- Port 443 (HTTPS) or 8080 (HTTP) is reachable
+- The URL in the Cline config is correct (with `/mcp` at the end)
+- Manual test: `curl -H "Authorization: Bearer lm_..." https://your-server/mcp`
+
+---
+
+## 🖥️ With Claude Desktop
+
+Configuration is similar. Edit the `claude_desktop_config.json` file:
+
+| OS          | Location                                                          |
+| ----------- | ----------------------------------------------------------------- |
+| **macOS**   | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| **Windows** | `%APPDATA%\Claude\claude_desktop_config.json`                     |
+| **Linux**   | `~/.config/Claude/claude_desktop_config.json`                     |
+
+```json
+{
+  "mcpServers": {
+    "live-memory": {
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "Authorization": "Bearer lm_YOUR_TOKEN_HERE"
+      },
+      "timeout": 600
+    }
+  }
+}
+```
+
+> **⚠️ Don't forget the `timeout` parameter** to allow long processing times during consolidation.
+
+Restart Claude Desktop after the change. The 38 Live Memory tools will appear in the available tools list.
+
+---
+
+## 📊 Summary
+
+| Step      | Action                                          | Time       |
+| --------- | ----------------------------------------------- | ---------- |
+| 1         | Start Live Memory (`docker compose up -d`)      | 1 min      |
+| 2         | Create a token (`mcp_cli.py token create`)      | 30 sec     |
+| 3         | Configure Cline (`cline_mcp_settings.json`)     | 2 min      |
+| 4         | Create a space (`space_create`)                 | 30 sec     |
+| 5         | Add the Custom Instructions                     | 2 min      |
+| **Total** | **Ready to use**                                | **~6 min** |
+
+---
+
+*Live Memory integration guide v1.2.0 — [Full documentation](README.en.md)*


### PR DESCRIPTION
## Contexte

Ce PR complète la documentation d'intégration des deux principaux agents IA avec Live Memory.

À ce jour, seul `GUIDE_INTEGRATION_CLINE.md` (FR) existait. Ce PR ajoute :

- **`GUIDE_INTEGRATION_CLAUDE_CODE.fr.md`** — Guide d'intégration FR pour Claude Code (Anthropic CLI).
- **`INTEGRATION_GUIDE_CLAUDE_CODE.en.md`** — Version EN du même guide.
- **`INTEGRATION_GUIDE_CLINE.en.md`** — Pendant EN du guide Cline déjà existant.

## Couverture

Pour chaque agent, les guides détaillent :

- Pré-requis (Docker, Compose, MCP CLI).
- Démarrage de Live Memory.
- Création d'un token dédié.
- Configuration de l'agent (`cline_mcp_settings.json` / `claude_desktop_config.json` ou équivalent).
- Création d'un space mémoire + custom instructions.
- Workflow recommandé (rules → bank_read_all → live_read → live_note → bank_consolidate).
- Scénarios multi-agents.
- Dépannage.

## Pas de changement de code

Documentation pure, aucun impact sur le runtime.

## Note sur le nommage

Les nouveaux fichiers reprennent la convention déjà en place côté README (`README.md` / `README.en.md`). Le guide Cline FR existant (`GUIDE_INTEGRATION_CLINE.md`) reste tel quel pour éviter un rename non sollicité ; si vous préférez normaliser tout en `*.fr.md` / `*.en.md`, je peux faire le suivi dans un PR séparé.
