### PR TITLE
feat(s3): make S3 signature mode configurable (dual / sigv4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,14 +13,22 @@ MCP_SERVER_DEBUG=false
 # ⚠️ Changer impérativement en production (≥ 32 chars aléatoires) !
 ADMIN_BOOTSTRAP_KEY=change_me_in_production
 
-# --- S3 Cloud Temple (Dell ECS) ---
-# Configuration HYBRIDE obligatoire : SigV2 pour PUT/GET/DELETE,
-# SigV4 pour HEAD/LIST. Path-style obligatoire.
+# --- S3 — Stockage objets ---
+# Path-style obligatoire pour tous les providers.
+#
+# S3_SIGNATURE_MODE :
+#   - "dual"  (défaut) : SigV2 pour PUT/GET/DELETE/COPY, SigV4 pour HEAD/LIST.
+#                        Requis pour Dell ECS Cloud Temple.
+#   - "sigv4"          : SigV4 pour toutes les opérations.
+#                        Recommandé pour MinIO, AWS S3, et tout provider
+#                        S3-compatible moderne (SigV2 déprécié AWS depuis 2018,
+#                        non supporté par MinIO).
 S3_ENDPOINT_URL=https://your-endpoint.s3.fr1.cloud-temple.com
 S3_ACCESS_KEY_ID=AKIA_YOUR_KEY
 S3_SECRET_ACCESS_KEY=your_secret
 S3_BUCKET_NAME=live-mem
 S3_REGION_NAME=fr1
+S3_SIGNATURE_MODE=dual
 
 # --- LLMaaS Cloud Temple ---
 # Le consolidateur utilise un LLM pour transformer les notes live en fichiers bank.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Ajouté
+- **Mode de signature S3 configurable (`S3_SIGNATURE_MODE`)** — Nouvelle variable d'environnement permettant de choisir entre :
+  - `dual` (défaut, comportement actuel) : SigV2 pour PUT/GET/DELETE/COPY + SigV4 pour HEAD/LIST. Requis pour Dell ECS Cloud Temple.
+  - `sigv4` : SigV4 pour toutes les opérations. Compatible MinIO, AWS S3 et autres providers S3-compatibles modernes (SigV2 est déprécié AWS depuis 2018 et non supporté par MinIO).
+  - Strictement rétrocompatible : sans changement de `.env`, le comportement Dell ECS Cloud Temple est conservé.
+  - Validation au démarrage : valeurs acceptées `dual` ou `sigv4` uniquement.
+
+### Fichiers modifiés
+| Fichier | Changements |
+| --- | --- |
+| `src/live_mem/config.py` | Nouveau champ `s3_signature_mode: str = "dual"` + validation `_validate_config` |
+| `src/live_mem/core/storage.py` | Refactor avec `_client_data` / `_client_meta`. En mode `dual` : SigV2 (data) + SigV4 (meta), identique à v1.8.1. En mode `sigv4` : un seul client SigV4 partagé. |
+| `.env.example` | Documentation de la nouvelle variable + bloc S3 mis à jour pour mentionner les providers non Cloud Temple |
+| `tests/test_config.py` | Nouvelle classe `TestS3SignatureMode` (4 tests) + ajout du champ dans `_make_settings` |
+
+---
+
 ## [1.8.1] — 2026-05-14
 
 ### Ajouté

--- a/src/live_mem/config.py
+++ b/src/live_mem/config.py
@@ -39,14 +39,20 @@ class Settings(BaseSettings):
     # ⚠️ Changer impérativement en production !
     admin_bootstrap_key: str = "change_me_in_production"
 
-    # ─── S3 Cloud Temple (Dell ECS) ────────────────────────────
-    # Configuration HYBRIDE obligatoire : SigV2 pour PUT/GET/DELETE,
-    # SigV4 pour HEAD/LIST. Voir CLOUD_TEMPLE_SERVICES.md.
+    # ─── S3 — Stockage objets ─────────────────────────────────
+    # Live Memory supporte deux modes de signature S3 :
+    #   - "dual" (défaut) : SigV2 pour PUT/GET/DELETE/COPY, SigV4 pour
+    #     HEAD/LIST. Requis pour Dell ECS Cloud Temple — voir
+    #     CLOUD_TEMPLE_SERVICES.md.
+    #   - "sigv4" : SigV4 pour toutes les opérations. Recommandé pour
+    #     MinIO, AWS S3, et tout provider S3-compatible moderne (SigV2
+    #     est déprécié AWS depuis 2018 et non supporté par MinIO).
     s3_endpoint_url: str = ""
     s3_access_key_id: str = ""
     s3_secret_access_key: str = ""
     s3_bucket_name: str = "live-mem"
     s3_region_name: str = "fr1"
+    s3_signature_mode: str = "dual"
 
     # ─── LLMaaS Cloud Temple ──────────────────────────────────
     # API OpenAI-compatible. L'URL INCLUT déjà /v1 — ne pas l'ajouter.
@@ -138,6 +144,14 @@ class Settings(BaseSettings):
             errors.append(
                 f"S3_ENDPOINT_URL must start with http:// or https://, "
                 f"got '{self.s3_endpoint_url[:50]}'"
+            )
+
+        # S3 signature mode
+        if self.s3_signature_mode not in ("dual", "sigv4"):
+            errors.append(
+                f"S3_SIGNATURE_MODE='{self.s3_signature_mode}' invalid — "
+                "must be 'dual' (Dell ECS Cloud Temple) or 'sigv4' "
+                "(MinIO / AWS S3 / other S3-compatible providers)"
             )
 
         # Bucket name: S3 naming rules (3-63 chars, lowercase, no underscore)

--- a/src/live_mem/core/storage.py
+++ b/src/live_mem/core/storage.py
@@ -2,14 +2,20 @@
 """
 Service S3 — Couche d'abstraction stockage pour Live Memory.
 
-Gère la communication avec le S3 Cloud Temple (Dell ECS) en utilisant
-une configuration HYBRIDE obligatoire :
-  - SigV2 (signature legacy) pour PUT/GET/DELETE (données)
-  - SigV4 (signature moderne) pour HEAD/LIST (métadonnées)
+Live Memory supporte deux modes de signature S3, contrôlés par la variable
+``S3_SIGNATURE_MODE`` :
 
-Voir CLOUD_TEMPLE_SERVICES.md pour les détails techniques.
+- ``dual`` (défaut) — Configuration HYBRIDE pour S3 Cloud Temple (Dell ECS) :
+    * SigV2 (signature legacy) pour PUT/GET/DELETE/COPY (données)
+    * SigV4 (signature moderne) pour HEAD/LIST (métadonnées)
+  Voir CLOUD_TEMPLE_SERVICES.md pour les détails techniques.
 
-Toutes les opérations sont wrappées dans run_in_executor car boto3
+- ``sigv4`` — SigV4 pour toutes les opérations. Compatible avec :
+    * MinIO (SigV2 non supporté depuis toujours)
+    * AWS S3 (SigV2 déprécié depuis 2018)
+    * Tout provider S3-compatible moderne
+
+Toutes les opérations sont wrappées dans ``run_in_executor`` car boto3
 est synchrone — on ne veut pas bloquer l'event loop asyncio.
 
 Usage :
@@ -40,12 +46,18 @@ logger = logging.getLogger("live_mem.storage")
 
 class StorageService:
     """
-    Service S3 avec dual client SigV2/SigV4 pour Dell ECS Cloud Temple.
+    Service S3 supportant deux modes de signature : ``dual`` (Dell ECS
+    Cloud Temple, SigV2+SigV4) et ``sigv4`` (MinIO / AWS / autres).
+
+    En mode ``sigv4``, ``_client_data`` et ``_client_meta`` pointent
+    vers le même client SigV4. En mode ``dual``, ce sont deux clients
+    distincts (SigV2 pour les données, SigV4 pour les métadonnées).
 
     Attributes:
         bucket: Nom du bucket S3
-        _client_v2: Client boto3 en signature V2 (PUT/GET/DELETE)
-        _client_v4: Client boto3 en signature V4 (HEAD/LIST)
+        signature_mode: 'dual' ou 'sigv4'
+        _client_data: Client boto3 pour PUT/GET/DELETE/COPY
+        _client_meta: Client boto3 pour HEAD/LIST
     """
 
     def __init__(self):
@@ -53,6 +65,7 @@ class StorageService:
 
         self.bucket = settings.s3_bucket_name
         self._endpoint = settings.s3_endpoint_url
+        self.signature_mode = settings.s3_signature_mode
 
         # ── Proxy HTTP sortant (optionnel) ────────────────────
         # Utilise PROXY_URL (variable custom) plutôt que HTTP_PROXY/HTTPS_PROXY
@@ -63,38 +76,21 @@ class StorageService:
             {"http": proxy_url, "https": proxy_url} if proxy_url else None
         )
 
-        # ── Client SigV2 — pour PUT/GET/DELETE (données) ──────
-        # Dell ECS exige SigV2 pour les opérations de données,
-        # sinon on obtient XAmzContentSHA256Mismatch.
-        config_v2 = Config(
-            region_name=settings.s3_region_name,
-            signature_version="s3",  # SigV2 legacy
-            s3={"addressing_style": "path"},  # Path-style obligatoire CT
-            retries={"max_attempts": 3, "mode": "adaptive"},
-            **({"proxies": _proxies} if _proxies else {}),
-        )
-        self._client_v2 = boto3.client(
-            "s3",
-            endpoint_url=settings.s3_endpoint_url,
-            aws_access_key_id=settings.s3_access_key_id,
-            aws_secret_access_key=settings.s3_secret_access_key,
-            config=config_v2,
-        )
-
-        # ── Client SigV4 — pour HEAD/LIST (métadonnées) ──────
-        # Dell ECS exige SigV4 pour HEAD bucket et LIST objects,
-        # sinon on obtient 403 Forbidden ou SignatureDoesNotMatch.
+        # ── Client SigV4 — toujours instancié ─────────────────
+        # Utilisé pour HEAD/LIST en mode "dual", et pour TOUT en mode "sigv4".
+        # payload_signing_enabled=False : optimisation réseau (pas de
+        # hash du body), supporté par Dell ECS, MinIO et AWS S3.
         config_v4 = Config(
             region_name=settings.s3_region_name,
             signature_version="s3v4",
             s3={
-                "addressing_style": "path",  # Path-style obligatoire CT
-                "payload_signing_enabled": False,  # Optimisation Dell ECS
+                "addressing_style": "path",
+                "payload_signing_enabled": False,
             },
             retries={"max_attempts": 3, "mode": "adaptive"},
             **({"proxies": _proxies} if _proxies else {}),
         )
-        self._client_v4 = boto3.client(
+        client_v4 = boto3.client(
             "s3",
             endpoint_url=settings.s3_endpoint_url,
             aws_access_key_id=settings.s3_access_key_id,
@@ -102,10 +98,35 @@ class StorageService:
             config=config_v4,
         )
 
+        if self.signature_mode == "dual":
+            # ── Client SigV2 — pour PUT/GET/DELETE/COPY (données) ─
+            # Dell ECS exige SigV2 pour les opérations de données,
+            # sinon on obtient XAmzContentSHA256Mismatch.
+            config_v2 = Config(
+                region_name=settings.s3_region_name,
+                signature_version="s3",  # SigV2 legacy
+                s3={"addressing_style": "path"},  # Path-style obligatoire CT
+                retries={"max_attempts": 3, "mode": "adaptive"},
+                **({"proxies": _proxies} if _proxies else {}),
+            )
+            self._client_data = boto3.client(
+                "s3",
+                endpoint_url=settings.s3_endpoint_url,
+                aws_access_key_id=settings.s3_access_key_id,
+                aws_secret_access_key=settings.s3_secret_access_key,
+                config=config_v2,
+            )
+            self._client_meta = client_v4
+        else:
+            # Mode "sigv4" — un seul client pour toutes les opérations.
+            self._client_data = client_v4
+            self._client_meta = client_v4
+
         logger.info(
-            "StorageService initialisé — bucket=%s endpoint=%s",
+            "StorageService initialisé — bucket=%s endpoint=%s signature_mode=%s",
             self.bucket,
             self._endpoint,
+            self.signature_mode,
         )
         if proxy_url:
             logger.info("StorageService: S3 requests via proxy %s", proxy_url)
@@ -120,7 +141,7 @@ class StorageService:
         return await loop.run_in_executor(None, partial(func, *args, **kwargs))
 
     # ─────────────────────────────────────────────────────────────
-    # PUT — Écriture (SigV2)
+    # PUT — Écriture (data client)
     # ─────────────────────────────────────────────────────────────
 
     async def put(
@@ -135,7 +156,7 @@ class StorageService:
             content_type: Type MIME (défaut: text/plain)
         """
         await self._run(
-            self._client_v2.put_object,
+            self._client_data.put_object,
             Bucket=self.bucket,
             Key=key,
             Body=content.encode("utf-8"),
@@ -154,7 +175,7 @@ class StorageService:
         await self.put(key, content, content_type="application/json")
 
     # ─────────────────────────────────────────────────────────────
-    # GET — Lecture (SigV2)
+    # GET — Lecture (data client)
     # ─────────────────────────────────────────────────────────────
 
     async def get(self, key: str) -> Optional[str]:
@@ -169,7 +190,7 @@ class StorageService:
         """
         try:
             response = await self._run(
-                self._client_v2.get_object,
+                self._client_data.get_object,
                 Bucket=self.bucket,
                 Key=key,
             )
@@ -197,7 +218,7 @@ class StorageService:
         return json.loads(content)
 
     # ─────────────────────────────────────────────────────────────
-    # DELETE — Suppression (SigV2)
+    # DELETE — Suppression (data client)
     # ─────────────────────────────────────────────────────────────
 
     async def delete(self, key: str) -> None:
@@ -208,7 +229,7 @@ class StorageService:
             key: Clé S3
         """
         await self._run(
-            self._client_v2.delete_object,
+            self._client_data.delete_object,
             Bucket=self.bucket,
             Key=key,
         )
@@ -218,7 +239,8 @@ class StorageService:
         Supprime plusieurs objets un par un.
 
         Note : Dell ECS ne supporte pas delete_objects (batch) avec SigV2.
-        On utilise des suppressions individuelles qui fonctionnent.
+        On utilise des suppressions individuelles qui fonctionnent sur
+        tous les providers (Dell ECS, MinIO, AWS).
 
         Args:
             keys: Liste des clés S3 à supprimer
@@ -241,7 +263,7 @@ class StorageService:
         return deleted
 
     # ─────────────────────────────────────────────────────────────
-    # LIST — Listage (SigV4)
+    # LIST — Listage (meta client)
     # ─────────────────────────────────────────────────────────────
 
     async def list_objects(self, prefix: str, max_keys: int = 0) -> list[dict]:
@@ -268,7 +290,7 @@ class StorageService:
                 params["ContinuationToken"] = continuation_token
 
             response = await self._run(
-                self._client_v4.list_objects_v2,
+                self._client_meta.list_objects_v2,
                 **params,
             )
 
@@ -320,7 +342,7 @@ class StorageService:
                 params["ContinuationToken"] = continuation_token
 
             response = await self._run(
-                self._client_v4.list_objects_v2,
+                self._client_meta.list_objects_v2,
                 **params,
             )
 
@@ -335,7 +357,7 @@ class StorageService:
         return all_prefixes
 
     # ─────────────────────────────────────────────────────────────
-    # HEAD — Existence (SigV4)
+    # HEAD — Existence (meta client)
     # ─────────────────────────────────────────────────────────────
 
     async def exists(self, key: str) -> bool:
@@ -350,7 +372,7 @@ class StorageService:
         """
         try:
             await self._run(
-                self._client_v4.head_object,
+                self._client_meta.head_object,
                 Bucket=self.bucket,
                 Key=key,
             )
@@ -412,7 +434,7 @@ class StorageService:
         """
         copy_source = {"Bucket": self.bucket, "Key": source_key}
         await self._run(
-            self._client_v2.copy_object,
+            self._client_data.copy_object,
             CopySource=copy_source,
             Bucket=self.bucket,
             Key=dest_key,
@@ -426,7 +448,7 @@ class StorageService:
         """
         Teste la connexion au bucket S3.
 
-        Utilise HEAD bucket (SigV4) pour vérifier l'accès.
+        Utilise HEAD bucket (meta client) pour vérifier l'accès.
 
         Returns:
             {"status": "ok", "bucket": "...", "latency_ms": ...} ou erreur
@@ -436,7 +458,7 @@ class StorageService:
         t0 = time.monotonic()
         try:
             await self._run(
-                self._client_v4.head_bucket,
+                self._client_meta.head_bucket,
                 Bucket=self.bucket,
             )
             latency = round((time.monotonic() - t0) * 1000, 1)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ def _make_settings(**overrides):
         "s3_secret_access_key": "",
         "s3_bucket_name": "live-mem",
         "s3_region_name": "fr1",
+        "s3_signature_mode": "dual",
         "llmaas_api_url": "",
         "llmaas_api_key": "",
         "llmaas_model": "test-model",
@@ -88,6 +89,24 @@ class TestS3Validation:
             s3_secret_access_key="",
         )
         assert s.s3_endpoint_url == ""
+
+
+class TestS3SignatureMode:
+    def test_dual_is_default(self):
+        s = _make_settings()
+        assert s.s3_signature_mode == "dual"
+
+    def test_sigv4_accepted(self):
+        s = _make_settings(s3_signature_mode="sigv4")
+        assert s.s3_signature_mode == "sigv4"
+
+    def test_invalid_mode_rejected(self):
+        with pytest.raises(ValueError, match="S3_SIGNATURE_MODE"):
+            _make_settings(s3_signature_mode="sigv2")
+
+    def test_empty_mode_rejected(self):
+        with pytest.raises(ValueError, match="S3_SIGNATURE_MODE"):
+            _make_settings(s3_signature_mode="")
 
 
 class TestLLMValidation:


### PR DESCRIPTION
## Résumé

Rend le mode de signature S3 configurable via une nouvelle variable d'environnement `S3_SIGNATURE_MODE` :

- **`dual`** (défaut, **comportement actuel inchangé**) : SigV2 pour PUT/GET/DELETE/COPY + SigV4 pour HEAD/LIST. Requis pour Dell ECS Cloud Temple.
- **`sigv4`** : SigV4 pour toutes les opérations. Compatible **MinIO**, **AWS S3**, et tout provider S3-compatible moderne (SigV2 est déprécié AWS depuis 2018 et n'a jamais été supporté par MinIO).

## Motivation

Live Memory tourne actuellement très bien sur Dell ECS Cloud Temple grâce à la config hybride SigV2/SigV4. Mais hors Cloud Temple, le client SigV2 casse :

- **MinIO** : refuse purement et simplement les requêtes SigV2 (jamais supporté).
- **AWS S3** : SigV2 déprécié depuis 2018 sur la quasi-totalité des régions modernes.

Aujourd'hui, déployer Live Memory contre l'un de ces backends nécessite un patch local pour supprimer le client SigV2. Cette PR transforme ce besoin récurrent en feature first-class : on **garde le comportement par défaut Cloud Temple intact** tout en permettant aux autres déploiements de passer en SigV4-only via un simple `S3_SIGNATURE_MODE=sigv4` dans `.env`.

## Implémentation

| Fichier | Changement |
|---|---|
| `src/live_mem/config.py` | Nouveau champ `s3_signature_mode: str = "dual"` + validation `_validate_config` (seules valeurs acceptées : `dual` ou `sigv4`). |
| `src/live_mem/core/storage.py` | Refactor avec deux clients nommés explicitement par rôle : `_client_data` (PUT/GET/DELETE/COPY) et `_client_meta` (HEAD/LIST). En mode `dual` : SigV2 + SigV4, **strictement identique à v1.8.1**. En mode `sigv4` : un seul client SigV4 partagé entre les deux rôles. |
| `.env.example` | Nouvelle entrée `S3_SIGNATURE_MODE=dual` avec documentation des deux modes et des providers supportés. |
| `tests/test_config.py` | Nouvelle classe `TestS3SignatureMode` (4 tests : défaut, `sigv4` accepté, valeur invalide rejetée, valeur vide rejetée). `s3_signature_mode` ajouté aux defaults de `_make_settings`. |
| `CHANGELOG.md` | Section `[Unreleased]` ajoutée. |

## Rétrocompatibilité

✅ **Strictement rétrocompatible.** Sans modification de `.env`, le défaut `dual` reproduit byte-pour-byte la configuration `boto3.client` actuelle (SigV2 pour les opérations de données, SigV4 pour les métadonnées). Aucun déploiement Cloud Temple n'est impacté.

## Tests

- Suite `tests/test_config.py` complète : **29 PASS** (25 existants + 4 nouveaux pour `S3_SIGNATURE_MODE`).
- Import `from live_mem.core import storage` validé après refactor (pas de cassure d'import).
- Test fonctionnel manuel : ce code tourne en production locale (sur MinIO/Synology) avec `S3_SIGNATURE_MODE=sigv4` depuis plusieurs semaines (en patch local de v1.8.1, exactement le même code). Aucun problème observé.

## Notes

- `payload_signing_enabled=False` reste actif dans la config SigV4 — c'est une optimisation réseau supportée par Dell ECS, MinIO **et** AWS S3.
- Le `path-style addressing` reste obligatoire dans les deux modes (compat tous providers).
- Le proxy HTTP sortant (v1.8.1) est correctement propagé aux deux clients dans les deux modes.

## Suite

Si l'approche convient, je pourrais ouvrir un follow-up court pour ajouter `S3_SIGNATURE_MODE` à la matrice de la doc déploiement et un exemple `docker-compose-minio.yml` minimal — mais à voir s'il a sa place ici, dites-moi.
