### PR TITLE
fix(bank): discourage automatic consolidation polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ docker-compose-local.yml
 
 # === MCP config (local) ===
 .mcp.json
+.codex/
 
 # === IDE ===
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **`bank_consolidate` no-auto-polling contract** (PR #22) — the async job
+  acknowledgement now carries a machine-readable contract telling callers not to
+  watch/poll automatically:
+  - New payload fields: `next_action="return_to_user_without_polling"` and
+    `polling={recommended:false, mode:"manual_only", status_tool:"bank_consolidation_status", instruction:…}`.
+  - Human-readable `message` field rephrased to make the call-once intent
+    explicit on both `running` and `queued` payloads.
+  - `bank_consolidation_status` is reclassified as a manual-only status check;
+    clients must not call it automatically after every `bank_consolidate`.
+  - Docs updated: `MCP_TOOLS_SPEC.md`, `CONCURRENCY.md`, `CONSOLIDATION_LLM.md`,
+    `FAQ.md`, `README.md`, integration guides.
+
+---
+
 ## [2.2.0] — 2026-05-19
 
 ### Added
@@ -41,8 +59,10 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Bank tool count**: 8 → 10 tools (+ `bank_consolidation_status`, `bank_consolidation_queues`).
   Total MCP tools: 40 → **42** (7 categories).
 - **`bank_consolidate` behavior**: returns `{"status": "running"|"queued"}` with `job_id`
-  instead of blocking until completion. Existing agents/scripts relying on synchronous
-  completion should poll `bank_consolidation_status(job_id)` or inspect `space_info`.
+  instead of blocking until completion. Caller contract: call once at session end and
+  return to the user — do not wait for completion and do not watch/poll automatically.
+  `bank_consolidation_status(job_id)` and `space_info` remain available for explicit
+  manual status checks only (see PR #22 for the machine-readable contract).
 - **FAQ.md**: "conflict" → "queued" language updated.
 - **DESIGN docs updated**: `CONCURRENCY.md`, `CONSOLIDATION_LLM.md`, `MCP_TOOLS_SPEC.md`
   reflect the async queue model.

--- a/CLAUDE_CODE_INTEGRATION.fr.md
+++ b/CLAUDE_CODE_INTEGRATION.fr.md
@@ -11,12 +11,12 @@ Ce guide détaille pas à pas comment connecter **Claude Code** (le CLI d'Anthro
 - [Prérequis](#-prérequis)
 - [Étape 1 — Démarrer Live Memory](#-étape-1--démarrer-live-memory)
 - [Étape 2 — Créer un token pour Claude Code](#-étape-2--créer-un-token-pour-claude-code)
-- [Étape 3 — Brancher Claude Code sur Live Memory](#-étape-3--brancher-claude-code-sur-live-memory)
+- [Étape 3 — Connecter Claude Code à Live Memory](#-étape-3--connecter-claude-code-à-live-memory)
 - [Étape 4 — Créer un espace mémoire](#-étape-4--créer-un-espace-mémoire)
-- [Étape 5 — Donner des instructions à Claude Code](#-étape-5--donner-des-instructions-à-claude-code)
+- [Étape 5 — Donner ses instructions à Claude Code](#-étape-5--donner-ses-instructions-à-claude-code)
 - [Workflow recommandé](#-workflow-recommandé)
-- [Multi-agents : Claude Code + Cline + Claude Desktop + autres](#-multi-agents--claude-code--cline--claude-desktop--autres)
-- [Dépannage](#-dépannage)
+- [Multi-agent : Claude Code + Cline + Claude Desktop + autres](#-multi-agent--claude-code--cline--claude-desktop--autres)
+- [Troubleshooting](#-troubleshooting)
 - [Avec Claude Desktop](#-avec-claude-desktop)
 - [Récapitulatif](#-récapitulatif)
 
@@ -29,9 +29,9 @@ Ce guide détaille pas à pas comment connecter **Claude Code** (le CLI d'Anthro
 | **Docker**           | ≥ 24.0             | `docker --version`                  |
 | **Docker Compose**   | v2                 | `docker compose version`            |
 | **Claude Code**      | ≥ 2.1              | `claude --version`                  |
-| **Live Memory**      | Déployé et running | `curl http://localhost:8080/health` |
+| **Live Memory**      | Déployé et démarré | `curl http://localhost:8080/health` |
 
-> 💡 Si Claude Code n'est pas installé : `npm install -g @anthropic-ai/claude-code` (macOS/Linux/Windows) ou via l'installateur dédié — voir la documentation officielle Anthropic. Claude Code expose la commande `claude` dans le terminal et propose des extensions IDE (VS Code, JetBrains) qui partagent la même configuration.
+> 💡 Si Claude Code n'est pas installé : `npm install -g @anthropic-ai/claude-code` (macOS/Linux/Windows) ou utilisez l'installateur dédié — voir la documentation officielle Anthropic. Claude Code fournit la commande `claude` dans le terminal et propose des extensions IDE (VS Code, JetBrains) qui partagent la même configuration.
 
 ---
 
@@ -42,12 +42,12 @@ Si Live Memory n'est pas encore démarré :
 ```bash
 cd /chemin/vers/live-memory
 cp .env.example .env
-# Éditer .env avec vos credentials S3, LLMaaS, et ADMIN_BOOTSTRAP_KEY
+# Éditer .env avec vos credentials S3, LLMaaS et ADMIN_BOOTSTRAP_KEY
 docker compose build
 docker compose up -d
 ```
 
-**Vérifier** :
+**Vérification** :
 
 ```bash
 # Doit retourner {"status": "ok", ...}
@@ -66,40 +66,40 @@ Claude Code a besoin d'un **Bearer Token** avec les permissions `read,write` pou
 cd /chemin/vers/live-memory
 export MCP_TOKEN=<votre_ADMIN_BOOTSTRAP_KEY>
 
-# Créer un token "read,write" pour Claude Code
+# Créer un token « read,write » pour Claude Code
 python scripts/mcp_cli.py token create claude-code-agent read,write
 ```
 
 La CLI affichera quelque chose comme :
 
 ```
-Token créé avec succès !
-  Nom    : claude-code-agent
+Token created successfully!
+  Name   : claude-code-agent
   Token  : lm_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9T0u1V2
   Perms  : read, write
 
-⚠️  Ce token ne sera PLUS JAMAIS affiché. Copiez-le maintenant !
+⚠️  This token will NEVER be displayed again. Copy it now!
 ```
 
-> **⚠️ IMPORTANT** : Copiez ce token immédiatement ! Il ne sera plus jamais affiché (seul le hash SHA-256 est stocké).
+> **⚠️ IMPORTANT** : copiez ce token immédiatement ! Il ne sera plus jamais affiché (seul le hash SHA-256 est stocké).
 
-### Option B — Via la bootstrap key (temporaire)
+### Option B — Via la clé bootstrap (temporaire)
 
-Pour un test rapide, vous pouvez utiliser directement la `ADMIN_BOOTSTRAP_KEY` définie dans votre `.env`. Mais **en production**, créez toujours un token dédié avec les permissions minimales.
+Pour un test rapide, vous pouvez utiliser directement l'`ADMIN_BOOTSTRAP_KEY` définie dans votre `.env`. Mais **en production**, créez toujours un token dédié avec des permissions minimales.
 
 ---
 
-## ⚙️ Étape 3 — Brancher Claude Code sur Live Memory
+## ⚙️ Étape 3 — Connecter Claude Code à Live Memory
 
-Claude Code stocke sa configuration MCP dans un fichier JSON. Trois scopes sont disponibles :
+Claude Code stocke sa configuration MCP dans un fichier JSON. Trois portées sont disponibles :
 
-| Scope     | Emplacement                                  | Portée                              |
-| --------- | -------------------------------------------- | ----------------------------------- |
-| `local`   | `~/.claude.json` (clé `projects.<cwd>`)      | Le répertoire courant uniquement    |
-| `user`    | `~/.claude.json` (clé `mcpServers` globale)  | Tous les projets de l'utilisateur   |
-| `project` | `.mcp.json` à la racine du projet            | Commité dans le repo (équipes)      |
+| Portée    | Emplacement                                    | Portée effective                   |
+| --------- | ---------------------------------------------- | ---------------------------------- |
+| `local`   | `~/.claude.json` (clé `projects.<cwd>`)        | Répertoire courant uniquement      |
+| `user`    | `~/.claude.json` (clé `mcpServers` au top)     | Tous les projets de l'utilisateur  |
+| `project` | `.mcp.json` à la racine du projet              | Commitée au repo (équipes)         |
 
-Pour une utilisation perso multi-projets, le scope `user` est généralement le plus pratique.
+Pour un usage personnel multi-projets, la portée `user` est généralement la plus pratique.
 
 ### 3.1 — Méthode CLI (recommandée)
 
@@ -109,7 +109,7 @@ claude mcp add \
   --scope user \
   live-memory \
   https://votre-serveur/mcp \
-  --header "Authorization: Bearer lm_VOTRE_TOKEN_ICI"
+  --header "Authorization: Bearer lm_YOUR_TOKEN_HERE"
 ```
 
 Pour un serveur local en HTTP :
@@ -120,12 +120,12 @@ claude mcp add \
   --scope user \
   live-memory \
   http://localhost:8080/mcp \
-  --header "Authorization: Bearer lm_VOTRE_TOKEN_ICI"
+  --header "Authorization: Bearer lm_YOUR_TOKEN_HERE"
 ```
 
-### 3.2 — Méthode édition manuelle
+### 3.2 — Édition manuelle
 
-Si vous préférez éditer directement le JSON, ajoutez le bloc suivant dans `~/.claude.json` (scope `user`, sous la clé `mcpServers` au premier niveau) :
+Si vous préférez éditer le JSON directement, ajoutez le bloc suivant à `~/.claude.json` (portée `user`, sous la clé `mcpServers` au top) :
 
 ```json
 {
@@ -134,16 +134,16 @@ Si vous préférez éditer directement le JSON, ajoutez le bloc suivant dans `~/
       "type": "http",
       "url": "https://votre-serveur/mcp",
       "headers": {
-        "Authorization": "Bearer lm_VOTRE_TOKEN_ICI"
+        "Authorization": "Bearer lm_YOUR_TOKEN_HERE"
       }
     }
   }
 }
 ```
 
-> **Remplacez** `lm_VOTRE_TOKEN_ICI` par le token obtenu à l'étape 2 et `votre-serveur` par votre domaine (ou `localhost:8080` en local).
+> **Remplacez** `lm_YOUR_TOKEN_HERE` par le token de l'étape 2 et `votre-serveur` par votre domaine (ou `localhost:8080` en local).
 
-Pour le scope `project` (configuration partagée en équipe), créez plutôt un fichier `.mcp.json` à la racine du projet avec le même format.
+Pour la portée `project` (config partagée avec l'équipe), créez un fichier `.mcp.json` à la racine du projet avec le même format.
 
 ### 3.3 — Vérifier la connexion
 
@@ -155,13 +155,13 @@ claude mcp list
 
 Vous devriez voir `live-memory` avec un statut connecté. Lancez ensuite Claude Code dans un projet et demandez :
 
-> *« Appelle `system_health` sur live-memory et donne-moi le retour. »*
+> *« Appelle `system_health` sur live-memory et montre-moi la réponse. »*
 
 Si Claude répond avec `{"status": "ok", ...}`, la connexion fonctionne.
 
 ### 3.4 — Whitelister les outils (éviter les prompts de permission)
 
-Claude Code demande confirmation à chaque appel d'outil MCP non autorisé. Pour éviter ces interruptions, ajoutez les outils Live Memory à la liste blanche du projet (ou de l'utilisateur).
+Claude Code demande confirmation à chaque appel d'outil MCP non autorisé. Pour éviter ces interruptions, ajoutez les outils Live Memory à l'allow-list du projet (ou de l'utilisateur).
 
 Créez ou éditez `.claude/settings.local.json` à la racine du projet :
 
@@ -184,21 +184,21 @@ Créez ou éditez `.claude/settings.local.json` à la racine du projet :
 }
 ```
 
-> 💡 **Convention de nommage** : Claude Code expose chaque outil MCP sous la forme `mcp__<nom-du-serveur>__<nom-de-l-outil>`. Si vous avez nommé votre serveur `live-memory-prod` à l'étape 3.1, remplacez le préfixe en conséquence.
+> 💡 **Convention de nommage** : Claude Code expose chaque outil MCP sous la forme `mcp__<nom-serveur>__<nom-outil>`. Si vous avez nommé votre serveur `live-memory-prod` à l'étape 3.1, ajustez le préfixe en conséquence.
 
 Alternative interactive : tapez `/permissions` dans une session Claude Code pour ouvrir l'éditeur de permissions.
 
-Pour une configuration globale (tous projets), utilisez plutôt `~/.claude/settings.json`.
+Pour une configuration globale (tous projets), utilisez `~/.claude/settings.json` à la place.
 
-### 3.5 — Serveur distant HTTPS
+### 3.5 — Serveur HTTPS distant
 
-Pour un déploiement production, l'URL et le bloc JSON sont identiques — seul le schéma change (`https://` au lieu de `http://`). Aucune option supplémentaire n'est nécessaire côté Claude Code.
+Pour un déploiement en production, l'URL et le bloc JSON sont identiques — seul le schéma change (`https://` au lieu de `http://`). Aucune option supplémentaire requise côté Claude Code.
 
 ---
 
 ## 📁 Étape 4 — Créer un espace mémoire
 
-Avant que Claude Code puisse écrire des notes, il faut un **espace mémoire** avec des **rules** qui définissent la structure de la Memory Bank.
+Avant que Claude Code puisse écrire des notes, il vous faut un **espace mémoire** avec des **rules** qui définissent la structure de la Memory Bank.
 
 ### Via la CLI
 
@@ -208,26 +208,26 @@ python scripts/mcp_cli.py space create mon-projet \
   -d "Mon projet de développement"
 ```
 
-Plusieurs templates de rules sont fournis dans le répertoire `RULES/` du repo :
+Plusieurs templates de rules sont fournis dans le dossier `RULES/` du repo :
 
-| Template                              | Usage                                                       |
-| ------------------------------------- | ----------------------------------------------------------- |
-| `RULES/standard.memory.bank.md`       | Memory Bank Cline classique (6 fichiers projet)             |
-| `RULES/product.management.memory.bank.md` | Équipe produit (vision, portfolio, personas, features)  |
-| `RULES/medical.memory.bank.md`        | Suivi de patient / dossier clinique                         |
-| `RULES/presales.memory.bank.md`       | Avant-vente, qualification de prospect, RFP                 |
-| `RULES/book.memory.bank.md`           | Écriture de livre / projet éditorial                        |
-| `RULES/live-mem.standard.memory.bank.md` | Développement du serveur Live Memory lui-même            |
+| Template                                  | Cas d'usage                                           |
+| ----------------------------------------- | ----------------------------------------------------- |
+| `RULES/standard.memory.bank.md`           | Memory Bank Cline classique (6 fichiers projet)       |
+| `RULES/product.management.memory.bank.md` | Équipe produit (vision, portfolio, personas, features) |
+| `RULES/medical.memory.bank.md`            | Suivi patient / dossier clinique                      |
+| `RULES/presales.memory.bank.md`           | Avant-vente, qualification de prospect, RFP           |
+| `RULES/book.memory.bank.md`               | Écriture de livre / projet éditorial                  |
+| `RULES/live-mem.standard.memory.bank.md`  | Développement du serveur Live Memory lui-même         |
 
 ### Via Claude Code directement
 
 Vous pouvez aussi demander à Claude de créer l'espace. Dites-lui simplement :
 
-> *« Utilise l'outil `space_create` pour créer un espace `mon-projet` avec des rules standard de type Memory Bank (projectbrief, activeContext, progress, techContext, systemPatterns, productContext). »*
+> *« Utilise l'outil `space_create` pour créer un space `mon-projet` avec les rules standards Memory Bank (projectbrief, activeContext, progress, techContext, systemPatterns, productContext). »*
 
-Claude Code utilisera l'outil MCP `space_create` pour le faire.
+Claude Code invoquera l'outil MCP `space_create`.
 
-### Exemple de rules standard
+### Exemple de rules standards
 
 ```markdown
 # Memory Bank Rules
@@ -238,10 +238,10 @@ Claude Code utilisera l'outil MCP `space_create` pour le faire.
 Vision, objectifs, périmètre du projet.
 
 ### activeContext.md
-Focus actuel, travail en cours, décisions récentes, prochaines étapes.
+Focus courant, travail en cours, décisions récentes, prochaines étapes.
 
 ### progress.md
-Ce qui fonctionne, ce qui reste à faire, problèmes connus.
+Ce qui marche, ce qui reste à faire, problèmes connus.
 
 ### techContext.md
 Technologies utilisées, configuration, contraintes techniques.
@@ -255,27 +255,27 @@ Pourquoi ce projet existe, problèmes résolus, expérience utilisateur.
 
 ---
 
-## 📝 Étape 5 — Donner des instructions à Claude Code
+## 📝 Étape 5 — Donner ses instructions à Claude Code
 
 Claude Code lit automatiquement les fichiers `CLAUDE.md` au démarrage. Deux emplacements possibles :
 
-| Emplacement             | Portée                                                | Recommandé pour                       |
-| ----------------------- | ----------------------------------------------------- | ------------------------------------- |
-| `<racine-projet>/CLAUDE.md` | Le projet courant (commité avec le repo)          | Workflow spécifique au projet         |
-| `~/.claude/CLAUDE.md`   | Tous les projets de l'utilisateur (privé, non commité) | Préférences globales, identité, style |
+| Emplacement                | Portée                                              | Recommandé pour                       |
+| -------------------------- | --------------------------------------------------- | ------------------------------------- |
+| `<racine-projet>/CLAUDE.md` | Le projet courant (committé avec le repo)          | Workflow spécifique au projet         |
+| `~/.claude/CLAUDE.md`      | Tous les projets de l'utilisateur courant (privé)   | Préférences globales, identité, style |
 
-Pour Live Memory, le `CLAUDE.md` projet est l'endroit idéal car la valeur de `{SPACE}` est spécifique au projet.
+Pour Live Memory, le `CLAUDE.md` au niveau projet est l'emplacement idéal car `{SPACE}` est spécifique au projet.
 
 ### Template recommandé (à coller dans `CLAUDE.md`)
 
-Ce template utilise le placeholder `{SPACE}` — il suffit de configurer **une seule valeur** :
+Ce template utilise le placeholder `{SPACE}` — vous n'avez qu'**une seule valeur** à configurer :
 
 ```markdown
 # Memory Bank — Live Memory MCP
 
 Ma mémoire se réinitialise complètement entre les sessions. Je dépends ENTIÈREMENT de la Memory Bank pour comprendre le projet et continuer efficacement.
 
-## 🔌 Configuration (à modifier par projet)
+## 🔌 Configuration (à personnaliser par projet)
 
 Ma mémoire persistante est gérée par le serveur MCP **Live Memory** (`live-memory`).
 
@@ -283,57 +283,59 @@ Ma mémoire persistante est gérée par le serveur MCP **Live Memory** (`live-me
 >
 > - **SPACE** = `mon-projet`       ← Remplacez par votre space_id
 >
-> Toutes les instructions ci-dessous utilisent `{SPACE}` — je le substitue automatiquement par la valeur ci-dessus.
-> Le nom de l'agent est **auto-détecté** depuis le token d'authentification (pas besoin de le configurer).
+> Toutes les instructions ci-dessous utilisent `{SPACE}` — je le remplace automatiquement par la valeur ci-dessus.
+> Le nom d'agent est **auto-détecté** depuis le token d'authentification (aucune configuration nécessaire).
 
-## 📖 Au démarrage de CHAQUE tâche (OBLIGATOIRE)
+## 📖 Au début de CHAQUE tâche (OBLIGATOIRE)
 
 1. Appeler `space_rules("{SPACE}")` pour lire les rules (structure de la bank)
 2. Appeler `bank_read_all("{SPACE}")` pour charger TOUT le contexte consolidé
 3. Appeler `live_read(space_id="{SPACE}")` pour lire les **notes non consolidées**
 4. Lire attentivement le contenu avant de commencer
-5. Identifier le focus actuel dans `activeContext.md`
+5. Identifier le focus courant dans `activeContext.md`
 
-> ⚠️ Ne JAMAIS commencer à travailler sans avoir lu la bank.
+> ⚠️ NE JAMAIS commencer à travailler sans avoir lu la bank.
 >
-> 💡 **Pourquoi lire les notes live ?** Entre deux sessions, des notes ont pu être écrites (par moi ou par d'autres agents) sans avoir été consolidées dans la bank. Ces notes contiennent du contexte récent qui n'apparaît pas encore dans les fichiers bank. Les ignorer = risquer de refaire du travail déjà fait ou de rater des décisions récentes.
+> 💡 **Pourquoi lire les notes live ?** Entre les sessions, des notes peuvent avoir été écrites (par moi ou par d'autres agents) sans avoir été consolidées. Ces notes contiennent du contexte récent qui n'apparaît pas encore dans les fichiers bank. Les ignorer = risque de refaire un travail déjà fait ou de manquer une décision récente.
 
 ## 📝 Pendant le travail
 
-Écrire des notes fréquentes et atomiques avec `live_note` :
+Écrire des notes atomiques fréquentes via `live_note` :
 
     live_note(space_id="{SPACE}", category="<catégorie>", content="...")
 
-Le paramètre `agent` est **auto-détecté** depuis le token — inutile de le passer.
+Le paramètre `agent` est **auto-détecté** depuis le token — pas besoin de le passer.
 
 **Catégories** :
-- `observation` — Constats factuels, résultats de commandes
-- `decision` — Choix techniques et leur justification
-- `progress` — Avancement, ce qui est terminé
-- `issue` — Problèmes rencontrés, bugs
-- `todo` — Tâches identifiées à faire
-- `insight` — Apprentissages, patterns découverts
-- `question` — Points à clarifier, décisions en suspens
+- `observation` — constats factuels, résultats de commandes
+- `decision` — choix techniques et leur justification
+- `progress` — avancement, travail terminé
+- `issue` — problèmes rencontrés, bugs
+- `todo` — tâches identifiées à faire
+- `insight` — apprentissages, patterns découverts
+- `question` — points à clarifier, décisions en attente
 
 ## 🧠 En fin de session (ou après un bloc de travail significatif)
 
     bank_consolidate(space_id="{SPACE}")
 
-Le LLM consolidera **mes propres notes** (auto-détection de l'agent depuis le token) en mettant à jour les fichiers de la bank selon les rules du space.
+Le LLM va consolider **mes propres notes** (agent auto-détecté depuis le token) en mettant à jour les fichiers bank selon les rules du space.
 
 > ℹ️ Seul un admin peut consolider les notes de tous les agents (`agent=""`).
+>
+> 🔕 `bank_consolidate` est **fire-and-forget** : il retourne un accusé async (`running` / `queued`) avec `next_action="return_to_user_without_polling"`. **Appelez-le une seule fois et rendez la main à l'utilisateur.** Ne surveillez pas et ne pollez pas. `bank_consolidation_status(job_id)` existe uniquement pour des **checks manuels explicites**.
 
-## ⚠️ Règles impératives
+## ⚠️ Règles strictes
 
-1. **Ne JAMAIS écrire directement dans la bank** — seule la consolidation LLM le fait
-2. **Toujours passer `space_id="{SPACE}"`** dans tous les appels
-3. **Écrire des notes atomiques après chaque étape importante** — 1 note = 1 fait, 1 décision, ou 1 tâche
-4. **Consolider en fin de session** — ne jamais quitter sans consolider mais toujours après avoir validé avec l'utilisateur
+1. **NE JAMAIS écrire directement dans la bank** — seule la consolidation LLM le fait
+2. **Toujours passer `space_id="{SPACE}"`** dans chaque appel
+3. **Écrire des notes atomiques après chaque étape significative** — 1 note = 1 fait, 1 décision, ou 1 tâche
+4. **Consolider en fin de session** — appelez `bank_consolidate` une seule fois et rendez la main à l'utilisateur sans poller (pas de boucle automatique sur `bank_consolidation_status`)
 5. **Lire la bank au démarrage** — ne jamais travailler sans contexte
 
 ## 🔄 Quand demander une mise à jour
 
-Si l'utilisateur demande **"update memory bank"** ou **"met à jour la memory bank"** :
+Si l'utilisateur dit **« update memory bank »** :
 1. Écrire des notes `live_note` résumant l'état actuel du travail
 2. Appeler `bank_consolidate(space_id="{SPACE}")`
 3. Vérifier le résultat avec `bank_read_all("{SPACE}")`
@@ -342,30 +344,30 @@ Si l'utilisateur demande **"update memory bank"** ou **"met à jour la memory ba
 
 | Action                          | Commande                                                                  |
 | ------------------------------- | ------------------------------------------------------------------------- |
-| Lire tout le contexte           | `bank_read_all("{SPACE}")`                                                |
+| Lire le contexte complet        | `bank_read_all("{SPACE}")`                                                |
 | Lire les rules                  | `space_rules("{SPACE}")`                                                  |
 | Écrire une note                 | `live_note(space_id="{SPACE}", category="...", content="...")`            |
 | Consolider                      | `bank_consolidate(space_id="{SPACE}")`                                    |
 | Voir les notes récentes         | `live_read(space_id="{SPACE}")`                                           |
 | Voir les notes d'un autre agent | `live_read(space_id="{SPACE}", agent="autre-agent")`                      |
-| Info sur l'espace               | `space_info("{SPACE}")`                                                   |
+| Infos space                     | `space_info("{SPACE}")`                                                   |
 ```
 
-> 💡 **Pour un nouveau projet** : copiez ce fichier dans `<racine-projet>/CLAUDE.md`, changez la ligne `SPACE`, c'est tout !
+> 💡 **Pour un nouveau projet** : copiez ce fichier dans `<racine-projet>/CLAUDE.md`, changez la ligne `SPACE`, et c'est tout !
 
 ### Version minimaliste (`~/.claude/CLAUDE.md` global)
 
-Si vous préférez ne pas commiter d'instructions Live Memory dans chaque projet, ajoutez ce bloc court dans `~/.claude/CLAUDE.md` :
+Si vous préférez ne pas committer les instructions Live Memory dans chaque projet, ajoutez ce court bloc à `~/.claude/CLAUDE.md` :
 
 ```
-Tu as accès à Live Memory (serveur MCP "live-memory").
-- Au démarrage: space_rules("{SPACE}"), bank_read_all("{SPACE}"), live_read("{SPACE}")
-- Pendant le travail: live_note(space_id="{SPACE}", category="...", content="...")
-- En fin de session: bank_consolidate(space_id="{SPACE}")
-Le `{SPACE}` est défini dans le CLAUDE.md du projet courant. L'agent est auto-détecté depuis le token.
+Vous avez accès à Live Memory (serveur MCP « live-memory »).
+- Au démarrage : space_rules("{SPACE}"), bank_read_all("{SPACE}"), live_read("{SPACE}")
+- Pendant le travail : live_note(space_id="{SPACE}", category="...", content="...")
+- En fin de session : bank_consolidate(space_id="{SPACE}") — appeler une seule fois et rendre la main sans poller
+`{SPACE}` est défini dans le CLAUDE.md du projet courant. L'agent est auto-détecté depuis le token.
 ```
 
-Chaque projet déclare ensuite uniquement sa valeur de `{SPACE}` dans son propre `CLAUDE.md`.
+Chaque projet déclare alors uniquement sa valeur `{SPACE}` dans son propre `CLAUDE.md`.
 
 ---
 
@@ -390,8 +392,8 @@ Chaque projet déclare ensuite uniquement sa valeur de `{SPACE}` dans son propre
 ├────────────────────────────────────────────────┤
 │  3. FIN DE SESSION                             │
 │     bank_consolidate("mon-projet")             │
-│     → LLM synthétise les notes en bank         │
-│     → Notes live supprimées après succès       │
+│     → Le LLM synthétise les notes dans la bank │
+│     → Les notes live sont supprimées si OK     │
 └────────────────────────────────────────────────┘
 ```
 
@@ -400,11 +402,11 @@ Chaque projet déclare ensuite uniquement sa valeur de `{SPACE}` dans son propre
 | Situation                   | Recommandation                       |
 | --------------------------- | ------------------------------------ |
 | Session courte (< 10 notes) | Consolider en fin de session         |
-| Session longue (> 20 notes) | Consolider toutes les 15-20 notes    |
+| Session longue (> 20 notes) | Consolider toutes les 15–20 notes    |
 | Changement de contexte      | Consolider avant de changer de sujet |
 | Fin de journée              | Toujours consolider                  |
 
-### Visualiser en temps réel
+### Visualisation en temps réel
 
 Pendant que Claude Code travaille, ouvrez l'interface web pour suivre en direct :
 
@@ -412,26 +414,26 @@ Pendant que Claude Code travaille, ouvrez l'interface web pour suivre en direct 
 http://localhost:8080/live
 ```
 
-Vous verrez les notes apparaître en temps réel dans la **Live Timeline** et la **Bank** se mettre à jour après chaque consolidation.
+Les notes apparaîtront en temps réel dans la **Live Timeline** et la **Bank** se mettra à jour après chaque consolidation.
 
 ---
 
-## 👥 Multi-agents : Claude Code + Cline + Claude Desktop + autres
+## 👥 Multi-agent : Claude Code + Cline + Claude Desktop + autres
 
 Live Memory permet à **plusieurs agents** de collaborer sur le même espace mémoire.
 
 ### Scénario : Claude Code (dev) + Cline (review) + Claude Desktop (synthèse)
 
-Pour que plusieurs agents collaborent, il suffit de leur créer **un token par identité** :
+Pour que plusieurs agents collaborent, créez **un token par identité** :
 
 1. `admin_create_token name="claude-code-dev"`
 2. `admin_create_token name="cline-review"`
-3. `admin_create_token name="claude-desktop-synthese"`
+3. `admin_create_token name="claude-desktop-synth"`
 4. Configurer chaque agent avec son propre token
 
-L'identité de l'agent est **automatiquement déduite de son token** à chaque fois qu'il appelle `live_note` ou `bank_consolidate`. Aucun paramètre `agent` à préciser.
+L'identité de l'agent est **automatiquement dérivée de son token** chaque fois qu'il appelle `live_note` ou `bank_consolidate`. Aucun paramètre `agent` à passer.
 
-### Communication entre agents
+### Communication inter-agents
 
 Les agents ne se parlent pas directement. Ils communiquent **via l'espace partagé** :
 
@@ -444,62 +446,62 @@ Claude Code   → live_read(category="decision")   ← voit la réponse
 
 ### Consolidation par agent
 
-Chaque agent consolide **ses propres notes** sans interférer avec celles des autres. Si un agent a les droits **admin**, il peut consolider les notes de tous les agents en appelant `bank_consolidate` (qui, pour un admin, traite par défaut tout le monde).
+Chaque agent consolide **ses propres notes** sans interférer avec les autres. Si un agent a des droits **admin**, il peut consolider les notes de tous les agents en appelant `bank_consolidate` (qui, pour un admin, traite tout le monde par défaut).
 
 ---
 
-## 🔍 Dépannage
+## 🔍 Troubleshooting
 
-### `claude mcp list` ne montre pas live-memory
+### `claude mcp list` n'affiche pas live-memory
 
-1. Vérifiez que le serveur est démarré : `curl http://localhost:8080/health`
-2. Vérifiez la syntaxe JSON dans `~/.claude.json` (pas de virgule trailing, accolades bien fermées)
-3. Quittez complètement Claude Code et relancez-le — le fichier n'est lu qu'au démarrage
-4. Inspectez les logs : `claude --debug` puis exécutez une session courte
+1. Vérifiez que le serveur est lancé : `curl http://localhost:8080/health`
+2. Vérifiez la syntaxe JSON dans `~/.claude.json` (pas de virgule traînante, accolades fermées)
+3. Quittez complètement Claude Code et relancez — le fichier n'est lu qu'au démarrage
+4. Inspectez les logs : `claude --debug` puis lancez une session courte
 
-### Erreur "401 Unauthorized"
+### Erreur « 401 Unauthorized »
 
-- Le token est incorrect, périmé ou révoqué
+- Le token est incorrect, expiré ou révoqué
 - Vérifiez que le header est bien `"Authorization": "Bearer lm_..."` (avec le préfixe `lm_`)
-- Attention aux espaces / sauts de ligne parasites lors du copier-coller du token
-- La bootstrap key fonctionne pour les tests mais créez un vrai token pour l'usage courant
+- Attention aux espaces ou retours à la ligne parasites lors du copier-coller du token
+- La clé bootstrap fonctionne pour les tests, mais créez un vrai token pour un usage normal
 
-### Erreur "Accès refusé à l'espace"
+### Erreur « Access denied to space »
 
-Le token est restreint à certains espaces (`space_ids`). Soit :
-- Créez un token sans restriction d'espace (paramètre `space_ids` vide)
-- Soit ajoutez l'espace au token : `admin_update_token(token_hash, space_ids="mon-projet", action="add")`
+Le token est restreint à certains spaces (`space_ids`). Soit :
+- Créez un token sans restriction de space (paramètre `space_ids` vide)
+- Soit ajoutez le space au token : `admin_update_token(token_hash, space_ids="mon-projet", action="add")`
 
-### Claude Code demande la permission à chaque appel
+### Claude Code demande une permission à chaque appel
 
-Whitelistez les outils via `.claude/settings.local.json` (voir Étape 3.4) ou tapez `/permissions` dans la session pour les ajouter interactivement.
+Whitelistez les outils via `.claude/settings.local.json` (voir Étape 3.4), ou tapez `/permissions` en session pour les ajouter interactivement.
 
-### Claude Code n'utilise pas Live Memory spontanément
+### Claude Code n'utilise pas Live Memory tout seul
 
-Sans `CLAUDE.md` explicite, Claude Code ne sait pas qu'il doit appeler ces outils en début de session. Ajoutez le template de l'Étape 5 dans `<racine-projet>/CLAUDE.md` ou `~/.claude/CLAUDE.md`.
+Sans un `CLAUDE.md` explicite, Claude Code ne sait pas qu'il doit appeler ces outils au démarrage d'une session. Ajoutez le template de l'étape 5 dans `<racine-projet>/CLAUDE.md` ou `~/.claude/CLAUDE.md`.
 
-### Le MCP ne se connecte pas derrière un VPN ou un proxy
+### MCP ne se connecte pas derrière un VPN ou un proxy
 
-Si Live Memory est sur un serveur distant, vérifiez :
-- Que le port 443 (HTTPS) ou 8080 (HTTP) est accessible
-- Que l'URL dans la config Claude Code est correcte (avec `/mcp` à la fin)
-- Testez manuellement : `curl -H "Authorization: Bearer lm_..." https://votre-serveur/mcp`
+Si Live Memory est sur un serveur distant, vérifiez que :
+- Le port 443 (HTTPS) ou 8080 (HTTP) est accessible
+- L'URL dans la config Claude Code est correcte (avec `/mcp` à la fin)
+- Test manuel : `curl -H "Authorization: Bearer lm_..." https://votre-serveur/mcp`
 
-### Suivre l'avancement d'une consolidation
+### Suivre une consolidation en cours
 
-Côté serveur, observez les logs :
+Côté serveur, suivez les logs :
 
 ```bash
 docker compose logs -f live-mem-service --tail 20
 ```
 
-Claude Code maintient la connexion HTTP ouverte pendant tout l'appel, donc une consolidation longue ne pose normalement pas de problème de timeout côté client.
+Claude Code maintient la connexion HTTP ouverte pendant tout l'appel, donc une consolidation longue ne provoque généralement pas de timeout côté client.
 
 ---
 
 ## 🖥️ Avec Claude Desktop
 
-La configuration est similaire à Claude Code mais le fichier change. Éditez `claude_desktop_config.json` :
+La configuration est similaire à Claude Code, mais le fichier change. Éditez `claude_desktop_config.json` :
 
 | OS          | Emplacement                                                       |
 | ----------- | ----------------------------------------------------------------- |
@@ -513,7 +515,7 @@ La configuration est similaire à Claude Code mais le fichier change. Éditez `c
     "live-memory": {
       "url": "http://localhost:8080/mcp",
       "headers": {
-        "Authorization": "Bearer lm_VOTRE_TOKEN_ICI"
+        "Authorization": "Bearer lm_YOUR_TOKEN_HERE"
       },
       "timeout": 600
     }
@@ -525,22 +527,22 @@ La configuration est similaire à Claude Code mais le fichier change. Éditez `c
 
 Redémarrez Claude Desktop après la modification. Les outils Live Memory apparaîtront dans la liste des outils disponibles.
 
-> ℹ️ **Note** : Claude Desktop ne propose pas de système d'allow-list par outil (contrairement à Claude Code). Les permissions se gèrent au niveau de l'application elle-même.
+> ℹ️ **Note** : Claude Desktop ne propose pas de système d'allow-list par outil (contrairement à Claude Code). Les permissions sont gérées au niveau application.
 
 ---
 
 ## 📊 Récapitulatif
 
-| Étape     | Action                                                | Temps      |
-| --------- | ----------------------------------------------------- | ---------- |
-| 1         | Démarrer Live Memory (`docker compose up -d`)         | 1 min      |
-| 2         | Créer un token (`mcp_cli.py token create`)            | 30 sec     |
-| 3         | Configurer Claude Code (`claude mcp add`)             | 1 min      |
-| 3.4       | Whitelister les outils (`.claude/settings.local.json`) | 1 min      |
-| 4         | Créer un espace (`space_create`)                      | 30 sec     |
-| 5         | Ajouter le `CLAUDE.md` du projet                      | 2 min      |
-| **Total** | **Prêt à utiliser**                                   | **~6 min** |
+| Étape     | Action                                                  | Temps      |
+| --------- | ------------------------------------------------------- | ---------- |
+| 1         | Démarrer Live Memory (`docker compose up -d`)           | 1 min      |
+| 2         | Créer un token (`mcp_cli.py token create`)              | 30 sec     |
+| 3         | Configurer Claude Code (`claude mcp add`)               | 1 min      |
+| 3.4       | Whitelister les outils (`.claude/settings.local.json`)  | 1 min      |
+| 4         | Créer un space (`space_create`)                         | 30 sec     |
+| 5         | Ajouter le `CLAUDE.md` du projet                        | 2 min      |
+| **Total** | **Prêt à l'emploi**                                     | **~6 min** |
 
 ---
 
-*Guide d'intégration Live Memory ↔ Claude Code v1.0.0 — [Documentation complète](README.md)*
+*Guide d'intégration Live Memory ↔ Claude Code v1.0.0 — [Documentation complète](README.fr.md)*

--- a/CLAUDE_CODE_INTEGRATION.md
+++ b/CLAUDE_CODE_INTEGRATION.md
@@ -322,13 +322,15 @@ The `agent` parameter is **auto-detected** from the token — no need to pass it
 The LLM will consolidate **my own notes** (agent auto-detected from token) by updating the bank files according to the space rules.
 
 > ℹ️ Only an admin can consolidate notes from all agents (`agent=""`).
+>
+> 🔕 `bank_consolidate` is **fire-and-forget**: it returns an async job ack (`running` / `queued`) with `next_action="return_to_user_without_polling"`. **Call it once and return to the user.** Do not watch or poll. `bank_consolidation_status(job_id)` exists for **explicit manual checks only**.
 
 ## ⚠️ Strict rules
 
 1. **NEVER write directly into the bank** — only the LLM consolidation does that
 2. **Always pass `space_id="{SPACE}"`** in every call
 3. **Write atomic notes after each significant step** — 1 note = 1 fact, 1 decision, or 1 task
-4. **Consolidate at session end** — never quit without consolidating, but always after validating with the user
+4. **Consolidate at session end** — call `bank_consolidate` once and return to the user without polling (no automatic `bank_consolidation_status` loop)
 5. **Read the bank at startup** — never work without context
 
 ## 🔄 When to request an update
@@ -361,7 +363,7 @@ If you'd rather not commit Live Memory instructions in every project, add this s
 You have access to Live Memory (MCP server "live-memory").
 - At startup: space_rules("{SPACE}"), bank_read_all("{SPACE}"), live_read("{SPACE}")
 - During work: live_note(space_id="{SPACE}", category="...", content="...")
-- At session end: bank_consolidate(space_id="{SPACE}")
+- At session end: bank_consolidate(space_id="{SPACE}") — call once and return without polling
 `{SPACE}` is defined in the current project's CLAUDE.md. The agent is auto-detected from the token.
 ```
 

--- a/CLINE_INTEGRATION_GUIDE.fr.md
+++ b/CLINE_INTEGRATION_GUIDE.fr.md
@@ -13,24 +13,24 @@ Ce guide détaille pas à pas comment connecter **Cline** (l'agent IA dans VS Co
 - [Étape 2 — Créer un token pour Cline](#-étape-2--créer-un-token-pour-cline)
 - [Étape 3 — Configurer Cline dans VS Code / VSCodium](#-étape-3--configurer-cline-dans-vs-code--vscodium)
 - [Étape 4 — Créer un espace mémoire](#-étape-4--créer-un-espace-mémoire)
-- [Étape 5 — Donner des instructions à Cline](#-étape-5--donner-des-instructions-à-cline)
+- [Étape 5 — Donner les instructions à Cline](#-étape-5--donner-les-instructions-à-cline)
 - [Workflow recommandé](#-workflow-recommandé)
-- [Custom Instructions pour Cline](#-custom-instructions-pour-cline)
-- [Multi-agents : Cline + Claude + autres](#-multi-agents--cline--claude--autres)
-- [Dépannage](#-dépannage)
+- [Instructions personnalisées pour Cline](#-instructions-personnalisées-pour-cline)
+- [Multi-agent : Cline + Claude + autres](#-multi-agent--cline--claude--autres)
+- [Troubleshooting](#-troubleshooting)
 - [Avec Claude Desktop](#-avec-claude-desktop)
 
 ---
 
 ## 📦 Prérequis
 
-| Composant                   | Version            | Vérification                        |
-| --------------------------- | ------------------ | ----------------------------------- |
-| **Docker**                  | ≥ 24.0             | `docker --version`                  |
-| **Docker Compose**          | v2                 | `docker compose version`            |
-| **VS Code** ou **VSCodium** | Récent             | —                                   |
-| **Extension Cline**         | Récente            | Installée depuis le marketplace     |
-| **Live Memory**             | Déployé et running | `curl http://localhost:8080/health` |
+| Composant                   | Version            | Vérification                          |
+| --------------------------- | ------------------ | ------------------------------------- |
+| **Docker**                  | ≥ 24.0             | `docker --version`                    |
+| **Docker Compose**          | v2                 | `docker compose version`              |
+| **VS Code** ou **VSCodium** | Récent             | —                                     |
+| **Extension Cline**         | Récente            | Installée depuis le marketplace       |
+| **Live Memory**             | Déployé et démarré | `curl http://localhost:8080/health`   |
 
 ---
 
@@ -41,12 +41,12 @@ Si Live Memory n'est pas encore démarré :
 ```bash
 cd /chemin/vers/live-memory
 cp .env.example .env
-# Éditer .env avec vos credentials S3, LLMaaS, et ADMIN_BOOTSTRAP_KEY
+# Éditer .env avec vos credentials S3, LLMaaS et ADMIN_BOOTSTRAP_KEY
 docker compose build
 docker compose up -d
 ```
 
-**Vérifier** :
+**Vérification** :
 
 ```bash
 # Doit retourner {"status": "ok", ...}
@@ -65,26 +65,26 @@ Cline a besoin d'un **Bearer Token** avec les permissions `read,write` pour lire
 cd /chemin/vers/live-memory
 export MCP_TOKEN=<votre_ADMIN_BOOTSTRAP_KEY>
 
-# Créer un token "write" pour Cline
+# Créer un token « write » pour Cline
 python scripts/mcp_cli.py token create cline-agent read,write
 ```
 
 La CLI affichera quelque chose comme :
 
 ```
-Token créé avec succès !
-  Nom    : cline-agent
+Token created successfully!
+  Name   : cline-agent
   Token  : lm_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9T0u1V2
   Perms  : read, write
 
-⚠️  Ce token ne sera PLUS JAMAIS affiché. Copiez-le maintenant !
+⚠️  This token will NEVER be displayed again. Copy it now!
 ```
 
-> **⚠️ IMPORTANT** : Copiez ce token immédiatement ! Il ne sera plus jamais affiché (seul le hash SHA-256 est stocké).
+> **⚠️ IMPORTANT** : copiez ce token immédiatement ! Il ne sera plus jamais affiché (seul le hash SHA-256 est stocké).
 
-### Option B — Via la bootstrap key (temporaire)
+### Option B — Via la clé bootstrap (temporaire)
 
-Pour un test rapide, vous pouvez utiliser directement la `ADMIN_BOOTSTRAP_KEY` définie dans votre `.env`. Mais **en production**, créez toujours un token dédié avec les permissions minimales.
+Pour un test rapide, vous pouvez utiliser directement l'`ADMIN_BOOTSTRAP_KEY` définie dans votre `.env`. Mais **en production**, créez toujours un token dédié avec des permissions minimales.
 
 ---
 
@@ -94,9 +94,9 @@ Pour un test rapide, vous pouvez utiliser directement la `ADMIN_BOOTSTRAP_KEY` d
 
 1. Ouvrez VS Code / VSCodium
 2. Ouvrez le panneau Cline (icône Cline dans la barre latérale)
-3. Cliquez sur l'icône **⚙️ Settings** (roue crantée) en haut du panneau Cline
-4. Cherchez **"MCP Servers"** ou cliquez sur l'onglet **MCP** 
-5. Cliquez sur **"Edit MCP Settings"** (ou le bouton pour éditer le JSON)
+3. Cliquez sur l'icône **⚙️ Settings** (engrenage) en haut du panneau Cline
+4. Cherchez **« MCP Servers »** ou cliquez sur l'onglet **MCP**
+5. Cliquez sur **« Edit MCP Settings »** (ou le bouton pour éditer le JSON)
 
 ### 3.2 Ajouter Live Memory comme serveur MCP
 
@@ -108,7 +108,7 @@ Dans le fichier `cline_mcp_settings.json` qui s'ouvre, ajoutez la configuration 
     "live-memory": {
       "url": "http://localhost:8080/mcp",
       "headers": {
-        "Authorization": "Bearer lm_VOTRE_TOKEN_ICI"
+        "Authorization": "Bearer lm_YOUR_TOKEN_HERE"
       },
       "timeout": 600
     }
@@ -116,26 +116,26 @@ Dans le fichier `cline_mcp_settings.json` qui s'ouvre, ajoutez la configuration 
 }
 ```
 
-> **Remplacez** `lm_VOTRE_TOKEN_ICI` par le token obtenu à l'étape 2.
-> **⚠️ Le paramètre `timeout` est critique** : La consolidation LLM peut prendre plus de 60 secondes (le timeout par défaut de Cline). Il est indispensable de l'augmenter à 600 secondes, en conformité avec votre configuration `.env`.
+> **Remplacez** `lm_YOUR_TOKEN_HERE` par le token obtenu à l'étape 2.
+> **⚠️ Le paramètre `timeout` est critique** : la consolidation LLM peut prendre plus de 60 secondes (timeout par défaut de Cline). Il est essentiel de l'augmenter à 600 secondes, en cohérence avec votre configuration `.env`.
 
-### 3.3 Où se trouve le fichier de config ?
+### 3.3 Où se trouve le fichier de configuration ?
 
-| OS                 | Emplacement typique                                                                                                 |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| **macOS**          | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`     |
-| **Linux**          | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`                         |
-| **VSCodium macOS** | `~/Library/Application Support/VSCodium/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
-| **VSCodium Linux** | `~/.config/VSCodium/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`                     |
+| OS                 | Emplacement typique                                                                                                  |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| **macOS**          | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`      |
+| **Linux**          | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`                          |
+| **VSCodium macOS** | `~/Library/Application Support/VSCodium/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`  |
+| **VSCodium Linux** | `~/.config/VSCodium/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`                      |
 
 ### 3.4 Vérifier la connexion
 
-Après avoir sauvegardé le fichier de config :
+Après avoir enregistré le fichier de config :
 
-1. **Redémarrez Cline** (ou rechargez VS Code avec `Ctrl+Shift+P` → "Developer: Reload Window")
-2. Dans le panneau Cline, cliquez sur l'onglet **MCP** 
-3. Vous devriez voir **"live-memory"** avec un indicateur vert ✅
-4. Cliquez dessus pour voir les **38 outils** disponibles
+1. **Redémarrez Cline** (ou rechargez VS Code avec `Ctrl+Shift+P` → « Developer: Reload Window »)
+2. Dans le panneau Cline, cliquez sur l'onglet **MCP**
+3. Vous devriez voir **« live-memory »** avec un indicateur vert ✅
+4. Cliquez dessus pour voir les **38 outils disponibles**
 
 ### 3.5 Serveur distant (production)
 
@@ -147,7 +147,7 @@ Si Live Memory est déployé sur un serveur avec HTTPS :
     "live-memory": {
       "url": "https://live-mem.votre-domaine.com/mcp",
       "headers": {
-        "Authorization": "Bearer lm_VOTRE_TOKEN_ICI"
+        "Authorization": "Bearer lm_YOUR_TOKEN_HERE"
       },
       "timeout": 600
     }
@@ -159,7 +159,7 @@ Si Live Memory est déployé sur un serveur avec HTTPS :
 
 ## 📁 Étape 4 — Créer un espace mémoire
 
-Avant que Cline puisse écrire des notes, il faut un **espace mémoire** avec des **rules** qui définissent la structure de la Memory Bank.
+Avant que Cline puisse écrire des notes, il vous faut un **espace mémoire** avec des **rules** qui définissent la structure de la Memory Bank.
 
 ### Via la CLI
 
@@ -173,11 +173,11 @@ python scripts/mcp_cli.py space create mon-projet \
 
 Vous pouvez aussi demander à Cline de créer l'espace. Dites-lui simplement :
 
-> *"Utilise l'outil `space_create` pour créer un espace 'mon-projet' avec des rules standard de type Memory Bank (projectbrief, activeContext, progress, techContext, systemPatterns, productContext)."*
+> *« Utilise l'outil `space_create` pour créer un space 'mon-projet' avec les rules standards Memory Bank (projectbrief, activeContext, progress, techContext, systemPatterns, productContext). »*
 
 Cline utilisera l'outil MCP `space_create` pour le faire.
 
-### Exemple de rules standard
+### Exemple de rules standards
 
 ```markdown
 # Memory Bank Rules
@@ -188,10 +188,10 @@ Cline utilisera l'outil MCP `space_create` pour le faire.
 Vision, objectifs, périmètre du projet.
 
 ### activeContext.md  
-Focus actuel, travail en cours, décisions récentes, prochaines étapes.
+Focus courant, travail en cours, décisions récentes, prochaines étapes.
 
 ### progress.md
-Ce qui fonctionne, ce qui reste à faire, problèmes connus.
+Ce qui marche, ce qui reste à construire, problèmes connus.
 
 ### techContext.md
 Technologies utilisées, configuration, contraintes techniques.
@@ -205,25 +205,27 @@ Pourquoi ce projet existe, problèmes résolus, expérience utilisateur.
 
 ---
 
-## 📝 Étape 5 — Donner des instructions à Cline
+## 📝 Étape 5 — Donner les instructions à Cline
 
 Pour que Cline utilise automatiquement Live Memory, ajoutez des **Custom Instructions** dans ses paramètres.
 
 ### 5.1 Où configurer les Custom Instructions
 
-Dans Cline : **Settings** → **Custom Instructions** (ou dans le fichier `.clinerules` de votre projet).
+Dans Cline : **Settings** → **Custom Instructions**, ou mieux, placez un fichier `WORKSPACE_CLINE_RULES.md` à la racine de votre projet (Cline le charge automatiquement comme instructions au niveau workspace).
 
-### 5.2 Instructions recommandées (template `{SPACE}`)
+Le dépôt fournit un template prêt à l'emploi : [`WORKSPACE_CLINE_RULES.md`](WORKSPACE_CLINE_RULES.md). Copiez-le simplement à la racine de votre projet et personnalisez la valeur `SPACE`.
 
-Copiez le contenu ci-dessous dans les **Custom Instructions** de votre agent (ou dans un fichier `.clinerules` à la racine de votre projet). Ce template utilise le placeholder `{SPACE}` — il suffit de configurer **une seule valeur** :
+### 5.2 Instructions recommandées (template avec `{SPACE}`)
+
+Copiez le contenu ci-dessous dans les **Custom Instructions** de votre agent (ou dans un fichier `.clinerules` à la racine de votre projet). Ce template utilise le placeholder `{SPACE}` — vous n'avez qu'**une seule valeur** à définir :
 
 
 ```markdown
-# Cline's Memory Bank — Live Memory MCP
+# Memory Bank de Cline — Live Memory MCP
 
 Ma mémoire se réinitialise complètement entre les sessions. Je dépends ENTIÈREMENT de la Memory Bank pour comprendre le projet et continuer efficacement.
 
-## 🔌 Configuration (à modifier par projet)
+## 🔌 Configuration (à personnaliser par projet)
 
 Ma mémoire persistante est gérée par le serveur MCP **Live Memory** (`my-live-mem`).
 
@@ -231,57 +233,59 @@ Ma mémoire persistante est gérée par le serveur MCP **Live Memory** (`my-live
 >
 > - **SPACE** = `mon-projet`       ← Remplacez par votre space_id
 >
-> Toutes les instructions ci-dessous utilisent `{SPACE}` — je le substitue automatiquement par la valeur ci-dessus.
-> Le nom de l'agent est **auto-détecté** depuis le token d'authentification (pas besoin de le configurer).
+> Toutes les instructions ci-dessous utilisent `{SPACE}` — je le remplace automatiquement par la valeur ci-dessus.
+> Le nom d'agent est **auto-détecté** depuis le token d'authentification (aucune configuration nécessaire).
 
-## 📖 Au démarrage de CHAQUE tâche (OBLIGATOIRE)
+## 📖 Au début de CHAQUE tâche (OBLIGATOIRE)
 
 1. Appeler `space_rules("{SPACE}")` pour lire les rules (structure de la bank)
 2. Appeler `bank_read_all("{SPACE}")` pour charger TOUT le contexte consolidé
 3. Appeler `live_read(space_id="{SPACE}")` pour lire les **notes non consolidées**
 4. Lire attentivement le contenu avant de commencer
-5. Identifier le focus actuel dans `activeContext.md`
+5. Identifier le focus courant dans `activeContext.md`
 
-> ⚠️ Ne JAMAIS commencer à travailler sans avoir lu la bank.
+> ⚠️ NE JAMAIS commencer à travailler sans avoir lu la bank.
 >
-> 💡 **Pourquoi lire les notes live ?** Entre deux sessions, des notes ont pu être écrites (par moi ou par d'autres agents) sans avoir été consolidées dans la bank. Ces notes contiennent du contexte récent qui n'apparaît pas encore dans les fichiers bank. Les ignorer = risquer de refaire du travail déjà fait ou de rater des décisions récentes.
+> 💡 **Pourquoi lire les notes live ?** Entre les sessions, des notes peuvent avoir été écrites (par moi ou par d'autres agents) sans avoir été consolidées dans la bank. Ces notes contiennent du contexte récent qui n'apparaît pas encore dans les fichiers bank. Les ignorer = risque de refaire un travail déjà fait ou de manquer une décision récente.
 
 ## 📝 Pendant le travail
 
-Écrire des notes fréquentes et atomiques avec `live_note` :
+Écrire des notes atomiques fréquentes avec `live_note` :
 
 live_note(space_id="{SPACE}", category="<catégorie>", content="...")
 
-Le paramètre `agent` est **auto-détecté** depuis le token — inutile de le passer.
+Le paramètre `agent` est **auto-détecté** depuis le token — pas besoin de le passer.
 
 **Catégories** :
-- `observation` — Constats factuels, résultats de commandes
-- `decision` — Choix techniques et leur justification
-- `progress` — Avancement, ce qui est terminé
-- `issue` — Problèmes rencontrés, bugs
-- `todo` — Tâches identifiées à faire
-- `insight` — Apprentissages, patterns découverts
-- `question` — Points à clarifier, décisions en suspens
+- `observation` — constats factuels, sorties de commandes
+- `decision` — choix techniques et leur justification
+- `progress` — avancement, ce qui est terminé
+- `issue` — problèmes rencontrés, bugs
+- `todo` — tâches identifiées à faire
+- `insight` — apprentissages, patterns découverts
+- `question` — points à clarifier, décisions en attente
 
 ## 🧠 En fin de session (ou après un bloc de travail significatif)
 
 bank_consolidate(space_id="{SPACE}")
 
-Le LLM consolidera **mes propres notes** (auto-détection de l'agent depuis le token) en mettant à jour les fichiers de la bank selon les rules du space.
+Le LLM va consolider **mes propres notes** (agent auto-détecté depuis le token) en mettant à jour les fichiers bank selon les rules du space.
 
-> ℹ️ Seul un admin peut consolider les notes de tous les agents (`agent=""`).
+> ℹ️ Seul un utilisateur manage+ peut consolider les notes de tous les agents (`agent=""`).
+>
+> 🔕 `bank_consolidate` est **fire-and-forget** : il retourne un accusé async (`running` / `queued`) avec `next_action="return_to_user_without_polling"`. **Appelez-le une seule fois et rendez la main à l'utilisateur.** Ne surveillez pas et ne pollez pas. `bank_consolidation_status(job_id)` existe uniquement pour des **checks manuels explicites**.
 
-## ⚠️ Règles impératives
+## ⚠️ Règles obligatoires
 
-1. **Ne JAMAIS écrire directement dans la bank** — seule la consolidation LLM le fait
-2. **Toujours passer `space_id="{SPACE}"`** dans tous les appels
-3. **Écrire des notes atomiques après chaque étape importante** — 1 note = 1 fait, 1 décision, ou 1 tâche
-4. **Consolider en fin de session** — ne jamais quitter sans consolider mais toujours après avoir validé avec l'utilisateur
+1. **NE JAMAIS écrire directement dans la bank** — seule la consolidation LLM le fait
+2. **Toujours passer `space_id="{SPACE}"`** dans chaque appel
+3. **Écrire des notes atomiques après chaque étape significative** — 1 note = 1 fait, 1 décision, ou 1 tâche
+4. **Consolider en fin de session** — appelez `bank_consolidate` une seule fois et rendez la main à l'utilisateur sans poller (pas de boucle automatique sur `bank_consolidation_status`)
 5. **Lire la bank au démarrage** — ne jamais travailler sans contexte
 
 ## 🔄 Quand demander une mise à jour
 
-Si l'utilisateur demande **"update memory bank"** ou **"met à jour la memory bank"** :
+Si l'utilisateur dit **« update memory bank »** :
 1. Écrire des notes `live_note` résumant l'état actuel du travail
 2. Appeler `bank_consolidate(space_id="{SPACE}")`
 3. Vérifier le résultat avec `bank_read_all("{SPACE}")`
@@ -296,10 +300,10 @@ Si l'utilisateur demande **"update memory bank"** ou **"met à jour la memory ba
 | Consolider                      | `bank_consolidate(space_id="{SPACE}")`                                    |
 | Voir les notes récentes         | `live_read(space_id="{SPACE}")`                                           |
 | Voir les notes d'un autre agent | `live_read(space_id="{SPACE}", agent="autre-agent")`                      |
-| Info sur l'espace               | `space_info("{SPACE}")`                                                   |
+| Infos space                     | `space_info("{SPACE}")`                                                   |
 ```
 
-> 💡 **Pour un nouveau projet** : copiez ce fichier, changez la ligne `SPACE`, c'est tout !
+> 💡 **Pour un nouveau projet** : copiez ce fichier, changez la ligne `SPACE`, et c'est tout !
 
 ---
 
@@ -324,21 +328,21 @@ Si l'utilisateur demande **"update memory bank"** ou **"met à jour la memory ba
 ├────────────────────────────────────────────────┤
 │  3. FIN DE SESSION                             │
 │     bank_consolidate("mon-projet")             │
-│     → LLM synthétise les notes en bank         │
-│     → Notes live supprimées après succès       │
+│     → Le LLM synthétise les notes dans la bank │
+│     → Les notes live sont supprimées si OK     │
 └────────────────────────────────────────────────┘
 ```
 
 ### Fréquence de consolidation
 
-| Situation                   | Recommandation                       |
-| --------------------------- | ------------------------------------ |
-| Session courte (< 10 notes) | Consolider en fin de session         |
-| Session longue (> 20 notes) | Consolider toutes les 15-20 notes    |
-| Changement de contexte      | Consolider avant de changer de sujet |
-| Fin de journée              | Toujours consolider                  |
+| Situation                    | Recommandation                           |
+| ---------------------------- | ---------------------------------------- |
+| Session courte (< 10 notes)  | Consolider en fin de session             |
+| Session longue (> 20 notes)  | Consolider toutes les 15-20 notes        |
+| Changement de contexte       | Consolider avant de changer de sujet     |
+| Fin de journée               | Toujours consolider                      |
 
-### Visualiser en temps réel
+### Visualisation en temps réel
 
 Pendant que Cline travaille, ouvrez l'interface web pour suivre en direct :
 
@@ -350,43 +354,43 @@ Vous verrez les notes apparaître en temps réel dans la **Live Timeline** et la
 
 ---
 
-## 📋 Custom Instructions pour Cline
+## 📋 Instructions personnalisées pour Cline
 
 ### Version template (recommandée)
 
-Copiez le contenu du fichier [`.clinerules/standard.memory.bank.md`](.clinerules/standard.memory.bank.md) dans vos Custom Instructions ou dans un fichier `.clinerules` à la racine de votre projet.
+Copiez [`WORKSPACE_CLINE_RULES.md`](WORKSPACE_CLINE_RULES.md) à la racine de votre projet. Cline charge automatiquement ce fichier comme instructions au niveau workspace.
 
-Modifiez ensuite **uniquement la valeur de `{SPACE}`** pour l'adapter à votre projet. Le nom de l'agent est auto-détecté.
+Modifiez ensuite **uniquement la valeur `SPACE`** pour correspondre à votre projet. Le nom d'agent est auto-détecté.
 
-### Version minimaliste (copier-coller dans Custom Instructions)
+### Version minimaliste (copier-coller dans les Custom Instructions)
 
 Si vous voulez une version ultra-courte, ajoutez ceci dans les Custom Instructions globales :
 
 ```
-Tu as accès à Live Memory (serveur MCP).
-- Au démarrage: space_rules("{SPACE}"), bank_read_all("{SPACE}"), live_read("{SPACE}")
-- Pendant le travail: live_note(space_id="{SPACE}", category="...", content="...")
-- En fin de session: bank_consolidate(space_id="{SPACE}")
+Vous avez accès à Live Memory (serveur MCP).
+- Au démarrage : space_rules("{SPACE}"), bank_read_all("{SPACE}"), live_read("{SPACE}")
+- Pendant le travail : live_note(space_id="{SPACE}", category="...", content="...")
+- En fin de session : bank_consolidate(space_id="{SPACE}") — appeler une seule fois et rendre la main sans poller
 Où {SPACE} = "mon-projet". L'agent est auto-détecté depuis le token.
 ```
 
 ---
 
-## 👥 Multi-agents : Cline + Claude + autres
+## 👥 Multi-agent : Cline + Claude + autres
 
 Live Memory permet à **plusieurs agents** de collaborer sur le même espace mémoire.
 
 ### Scénario : Cline (dev) + Claude (review)
 
-Pour que deux agents collaborent, il suffit de leur créer **deux tokens différents** :
+Pour que deux agents collaborent, créez simplement **deux tokens différents** :
 
 1. Créer le token pour Cline (`admin_create_token name="cline-dev"`)
 2. Créer le token pour Claude (`admin_create_token name="claude-review"`)
 3. Configurer chaque agent avec son propre token
 
-L'identité de l'agent est **automatiquement déduite de son token** à chaque fois qu'il appelle `live_note` ou `bank_consolidate`. Ils n'ont pas besoin de le préciser.
+L'identité de l'agent est **automatiquement inférée depuis son token** chaque fois qu'il appelle `live_note` ou `bank_consolidate`. Ils n'ont pas besoin de la spécifier.
 
-### Communication entre agents
+### Communication inter-agents
 
 Les agents ne se parlent pas directement. Ils communiquent **via l'espace partagé** :
 
@@ -399,54 +403,54 @@ Cline  → live_read(category="decision")  ← voit la réponse de Claude
 
 ### Consolidation par agent
 
-Chaque agent consolide **ses propres notes** sans interférer avec celles des autres :
+Chaque agent consolide **ses propres notes** sans interférer avec les autres :
 
 ```
-Cline  → bank_consolidate(space_id="mon-projet")  # Ne consolide QUE les notes de cline-dev
-Claude → bank_consolidate(space_id="mon-projet")  # Ne consolide QUE les notes de claude-review
+Cline  → bank_consolidate(space_id="mon-projet")  # Consolide seulement les notes de cline-dev
+Claude → bank_consolidate(space_id="mon-projet")  # Consolide seulement les notes de claude-review
 ```
 
-Si un agent a les droits **admin**, il peut consolider les notes de tout le monde en appelant `bank_consolidate` (qui par défaut traite tout le monde pour un admin).
+Si un agent a des permissions **admin**, il peut consolider les notes de tout le monde en appelant `bank_consolidate` (qui par défaut traite tous les agents pour un admin).
 
 ---
 
-## 🔍 Dépannage
+## 🔍 Troubleshooting
 
 ### Cline ne voit pas les outils Live Memory
 
-1. Vérifiez que le serveur est démarré : `curl http://localhost:8080/health`
-2. Vérifiez la syntaxe JSON dans `cline_mcp_settings.json` (pas de virgule trailing)
-3. Rechargez VS Code (`Ctrl+Shift+P` → "Developer: Reload Window")
+1. Vérifiez que le serveur est lancé : `curl http://localhost:8080/health`
+2. Vérifiez la syntaxe JSON dans `cline_mcp_settings.json` (pas de virgule traînante)
+3. Rechargez VS Code (`Ctrl+Shift+P` → « Developer: Reload Window »)
 4. Dans l'onglet MCP de Cline, vérifiez si `live-memory` apparaît en rouge (erreur de connexion)
 
-### Erreur "401 Unauthorized"
+### Erreur « 401 Unauthorized »
 
 - Le token est incorrect ou révoqué
 - Vérifiez que le header est bien `"Authorization": "Bearer lm_..."` (avec le préfixe `lm_`)
-- La bootstrap key fonctionne pour les tests mais créez un vrai token pour l'usage courant
+- La clé bootstrap fonctionne pour tester, mais créez un vrai token pour un usage régulier
 
-### Erreur "Accès refusé à l'espace"
+### Erreur « Access Denied to Space »
 
-Le token est restreint à certains espaces (`space_ids`). Soit :
-- Créez un token sans restriction d'espace (paramètre `space_ids` vide)
-- Soit ajoutez l'espace au token : `admin_update_token(token_hash, space_ids="mon-projet", action="add")`
+Le token est restreint à certains spaces (`space_ids`). Soit :
+- Créez un token sans restriction de space (paramètre `space_ids` vide)
+- Soit ajoutez le space au token : `admin_update_token(token_hash, space_ids="mon-projet", action="add")`
 
 ### Cline n'utilise pas Live Memory spontanément
 
-Ajoutez des **Custom Instructions** explicites (voir [Étape 5](#-étape-5--donner-des-instructions-à-cline)). Sans instructions, Cline ne sait pas qu'il doit utiliser ces outils.
+Ajoutez des **Custom Instructions** explicites (voir [Étape 5](#-étape-5--donner-les-instructions-à-cline)). Sans instructions, Cline ne sait pas qu'il doit utiliser ces outils.
 
-### Erreur de timeout / La consolidation échoue après 60 secondes
+### Erreur de timeout / la consolidation échoue après 60 secondes
 
 Par défaut, Cline et Claude Desktop interrompent les requêtes MCP après 60 secondes, ce qui est souvent insuffisant pour une consolidation (le LLM peut prendre plusieurs minutes).
 
-1. Vérifiez que vous avez bien ajouté `"timeout": 600` dans la configuration MCP de votre agent, en conformité avec le timeout serveur configuré dans votre fichier `.env`.
-2. Vous pouvez suivre l'avancement réel côté serveur dans les logs :
+1. Vérifiez que vous avez ajouté `"timeout": 600` dans la configuration MCP de votre agent, en cohérence avec le timeout serveur dans votre fichier `.env`.
+2. Vous pouvez suivre la progression en temps réel côté serveur dans les logs :
 
 ```bash
 docker compose logs -f live-mem-service --tail 20
 ```
 
-### Le MCP ne se connecte pas derrière un VPN
+### MCP ne se connecte pas derrière un VPN
 
 Si Live Memory est sur un serveur distant, vérifiez :
 - Que le port 443 (HTTPS) ou 8080 (HTTP) est accessible
@@ -471,7 +475,7 @@ La configuration est similaire. Éditez le fichier `claude_desktop_config.json` 
     "live-memory": {
       "url": "http://localhost:8080/mcp",
       "headers": {
-        "Authorization": "Bearer lm_VOTRE_TOKEN_ICI"
+        "Authorization": "Bearer lm_YOUR_TOKEN_HERE"
       },
       "timeout": 600
     }
@@ -479,7 +483,7 @@ La configuration est similaire. Éditez le fichier `claude_desktop_config.json` 
 }
 ```
 
-> **⚠️ N'oubliez pas le paramètre `timeout`** pour autoriser les temps de traitement longs lors de la consolidation.
+> **⚠️ N'oubliez pas le paramètre `timeout`** pour autoriser les temps de traitement longs de la consolidation.
 
 Redémarrez Claude Desktop après la modification. Les 38 outils Live Memory apparaîtront dans la liste des outils disponibles.
 
@@ -487,15 +491,15 @@ Redémarrez Claude Desktop après la modification. Les 38 outils Live Memory app
 
 ## 📊 Récapitulatif
 
-| Étape     | Action                                        | Temps      |
-| --------- | --------------------------------------------- | ---------- |
-| 1         | Démarrer Live Memory (`docker compose up -d`) | 1 min      |
-| 2         | Créer un token (`mcp_cli.py token create`)    | 30 sec     |
-| 3         | Configurer Cline (`cline_mcp_settings.json`)  | 2 min      |
-| 4         | Créer un espace (`space_create`)              | 30 sec     |
-| 5         | Ajouter les Custom Instructions               | 2 min      |
-| **Total** | **Prêt à utiliser**                           | **~6 min** |
+| Étape     | Action                                            | Temps      |
+| --------- | ------------------------------------------------- | ---------- |
+| 1         | Démarrer Live Memory (`docker compose up -d`)     | 1 min      |
+| 2         | Créer un token (`mcp_cli.py token create`)        | 30 sec     |
+| 3         | Configurer Cline (`cline_mcp_settings.json`)      | 2 min      |
+| 4         | Créer un space (`space_create`)                   | 30 sec     |
+| 5         | Ajouter les Custom Instructions                   | 2 min      |
+| **Total** | **Prêt à l'emploi**                               | **~6 min** |
 
 ---
 
-*Guide d'intégration Live Memory v1.2.0 — [Documentation complète](README.md)*
+*Guide d'intégration Live Memory v1.2.0 — [Documentation complète](README.fr.md)*

--- a/CLINE_INTEGRATION_GUIDE.md
+++ b/CLINE_INTEGRATION_GUIDE.md
@@ -272,13 +272,15 @@ bank_consolidate(space_id="{SPACE}")
 The LLM will consolidate **my own notes** (agent auto-detected from the token) by updating the bank files according to the space's rules.
 
 > ℹ️ Only a manage+ user can consolidate all agents' notes (`agent=""`).
+>
+> 🔕 `bank_consolidate` is **fire-and-forget**: it returns an async job ack (`running` / `queued`) with `next_action="return_to_user_without_polling"`. **Call it once and return to the user.** Do not watch or poll. `bank_consolidation_status(job_id)` exists for **explicit manual checks only**.
 
 ## ⚠️ Mandatory Rules
 
 1. **NEVER write directly to the bank** — only the LLM consolidation does that
 2. **Always pass `space_id="{SPACE}"`** in every call
 3. **Write atomic notes after each significant step** — 1 note = 1 fact, 1 decision, or 1 task
-4. **Consolidate at session end** — never leave without consolidating, but always after validating with the user
+4. **Consolidate at session end** — call `bank_consolidate` once and return to the user without polling (no automatic `bank_consolidation_status` loop)
 5. **Read the bank at startup** — never work without context
 
 ## 🔄 When to Request an Update
@@ -368,7 +370,7 @@ If you want an ultra-short version, add this to the global Custom Instructions:
 You have access to Live Memory (MCP server).
 - At startup: space_rules("{SPACE}"), bank_read_all("{SPACE}"), live_read("{SPACE}")
 - During work: live_note(space_id="{SPACE}", category="...", content="...")
-- At session end: bank_consolidate(space_id="{SPACE}")
+- At session end: bank_consolidate(space_id="{SPACE}") — call once and return without polling
 Where {SPACE} = "my-project". The agent is auto-detected from the token.
 ```
 

--- a/CODEX_INTEGRATION.fr.md
+++ b/CODEX_INTEGRATION.fr.md
@@ -2,35 +2,35 @@
 
 > **Version** : 2.1.0 | **Date** : 2026-05-16
 
-Ce guide vous accompagne pas à pas pour connecter **OpenAI Codex** à **Live Memory**, lui offrant une mémoire de travail partagée et persistante entre les sessions de codage.
+Ce guide vous accompagne pour connecter **OpenAI Codex** à **Live Memory**, lui donnant une mémoire de travail partagée et persistante entre les sessions de coding.
 
 ---
 
-## 📋 Table des matières
+## 📋 Sommaire
 
 - [Prérequis](#-prérequis)
 - [Étape 1 — Obtenir un token Live Memory](#-étape-1--obtenir-un-token-live-memory)
 - [Étape 2 — Configurer Codex via `.codex/config.toml`](#-étape-2--configurer-codex-via-codexconfigtoml)
 - [Étape 3 — Créer un espace mémoire](#-étape-3--créer-un-espace-mémoire)
-- [Étape 4 — Donner des instructions à Codex](#-étape-4--donner-des-instructions-à-codex)
+- [Étape 4 — Donner les instructions à Codex](#-étape-4--donner-les-instructions-à-codex)
 - [Workflow recommandé](#-workflow-recommandé)
-- [Dépannage](#-dépannage)
+- [Troubleshooting](#-troubleshooting)
 
 ---
 
 ## 📦 Prérequis
 
-| Composant        | Détail                                                         |
-| ---------------- | -------------------------------------------------------------- |
-| **OpenAI Codex** | CLI ou environnement avec support des serveurs MCP             |
-| **Live Memory**  | Instance active (auto-hébergée ou service managé Cloud Temple) |
-| **Token Bearer** | Token `read,write` créé sur votre instance Live Memory         |
+| Composant          | Détail                                                              |
+| ------------------ | ------------------------------------------------------------------- |
+| **OpenAI Codex**   | CLI ou environnement supportant les serveurs MCP                    |
+| **Live Memory**    | Instance opérationnelle (auto-hébergée ou service managé Cloud Temple) |
+| **Bearer Token**   | Token `read,write` créé sur votre instance Live Memory              |
 
 ---
 
 ## 🔑 Étape 1 — Obtenir un token Live Memory
 
-Codex a besoin d'un **Token Bearer** avec au minimum les permissions `read,write`.
+Codex a besoin d'un **Bearer Token** avec au minimum les permissions `read,write`.
 
 ### Option A — Via la CLI
 
@@ -38,52 +38,52 @@ Codex a besoin d'un **Token Bearer** avec au minimum les permissions `read,write
 cd /chemin/vers/live-memory
 export MCP_TOKEN=<votre_ADMIN_BOOTSTRAP_KEY>
 
-# Créer un token "write" pour Codex
+# Créer un token « write » pour Codex
 python scripts/mcp_cli.py token create codex-agent read,write
 ```
 
-La CLI affiche quelque chose comme :
+La CLI affichera quelque chose comme :
 
 ```
-Token créé avec succès !
-  Nom    : codex-agent
+Token created successfully!
+  Name   : codex-agent
   Token  : lm_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9T0u1V2
   Perms  : read, write
 
-⚠️  Ce token ne sera JAMAIS affiché à nouveau. Copiez-le maintenant !
+⚠️  This token will NEVER be displayed again. Copy it now!
 ```
 
-> **⚠️ IMPORTANT** : Copiez ce token immédiatement ! Il ne sera jamais réaffiché (seul le hash SHA-256 est stocké).
+> **⚠️ IMPORTANT** : copiez ce token immédiatement ! Il ne sera plus jamais affiché (seul le hash SHA-256 est stocké).
 
 ### Option B — Via la console d'administration
 
 1. Ouvrez `https://<votre-instance-live-mem>/admin` dans votre navigateur
-2. Connectez-vous avec vos identifiants administrateur
-3. Naviguez vers **Admin → Tokens**
-4. Cliquez sur **Créer un token**, renseignez le nom (`codex-agent`), définissez les permissions à `read,write`
+2. Connectez-vous avec vos identifiants admin
+3. Allez dans **Admin → Tokens**
+4. Cliquez sur **Create Token**, renseignez le nom (`codex-agent`), définissez les permissions sur `read,write`
 5. Copiez le token affiché
 
 ### Option C — Service managé Cloud Temple
 
-Si vous utilisez l'instance **Live Memory managée par Cloud Temple**, votre token a déjà été provisionné. Il ressemble à ceci :
+Si vous utilisez l'instance **Live Memory managée par Cloud Temple**, votre token a déjà été provisionné. Utilisez-le directement — il ressemble à :
 
 ```
 lm_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-> ⚠️ Votre token est confidentiel. Ne l'incluez jamais dans une documentation ou dans un dépôt Git.
+> ⚠️ Votre token est confidentiel. Ne l'incluez jamais dans la documentation et ne le commitez jamais dans un dépôt.
 
 ---
 
 ## ⚙️ Étape 2 — Configurer Codex via `.codex/config.toml`
 
-Codex lit sa configuration de serveurs MCP depuis le fichier `.codex/config.toml` à la racine de votre projet (ou dans votre répertoire personnel pour une configuration globale).
+Codex lit la configuration de ses serveurs MCP depuis `.codex/config.toml`, à la racine de votre projet (ou dans votre dossier home pour une configuration globale).
 
 ### 2.1 Créer ou éditer le fichier de configuration
 
 ```bash
 mkdir -p ~/.codex
-# ou au niveau du projet :
+# ou au niveau projet :
 mkdir -p .codex
 ```
 
@@ -93,56 +93,56 @@ Ouvrez `.codex/config.toml` et ajoutez la section suivante :
 
 ```toml
 [mcp_servers.my-live-mem]
-http_headers = { "Authorization" = "Bearer lm_VOTRE_TOKEN_ICI" }
+http_headers = { "Authorization" = "Bearer lm_YOUR_TOKEN_HERE" }
 enabled = true
 url = "https://my.live-mem.mcp.cloud-temple.app/mcp"
 ```
 
-> **Remplacez** `lm_VOTRE_TOKEN_ICI` par le token obtenu à l'étape 1.
+> **Remplacez** `lm_YOUR_TOKEN_HERE` par le token obtenu à l'étape 1.
 
 ### 2.3 Exemple complet avec le service managé Cloud Temple
 
 ```toml
 [mcp_servers.my-live-mem]
-http_headers = { "Authorization" = "Bearer lm_VOTRE_TOKEN_ICI" }
+http_headers = { "Authorization" = "Bearer lm_YOUR_TOKEN_HERE" }
 enabled = true
 url = "https://my.live-mem.mcp.cloud-temple.app/mcp"
 ```
 
-### 2.4 Exemple avec une instance auto-hébergée
+### 2.4 Exemple en instance auto-hébergée
 
 ```toml
 [mcp_servers.live-memory]
-http_headers = { "Authorization" = "Bearer lm_VOTRE_TOKEN_ICI" }
+http_headers = { "Authorization" = "Bearer lm_YOUR_TOKEN_HERE" }
 enabled = true
 url = "https://live-mem.votre-domaine.com/mcp"
 ```
 
-Pour une instance de développement local :
+Pour une instance de développement locale :
 
 ```toml
 [mcp_servers.live-memory]
-http_headers = { "Authorization" = "Bearer lm_VOTRE_TOKEN_ICI" }
+http_headers = { "Authorization" = "Bearer lm_YOUR_TOKEN_HERE" }
 enabled = true
 url = "http://localhost:8080/mcp"
 ```
 
 ### 2.5 Où placer `config.toml`
 
-| Portée         | Emplacement                          | Quand l'utiliser                           |
-| -------------- | ------------------------------------ | ------------------------------------------ |
-| **Global**     | `~/.codex/config.toml`               | Tous les projets partagent le même serveur |
-| **Par projet** | `<racine-projet>/.codex/config.toml` | Configuration MCP spécifique au projet     |
+| Portée          | Emplacement                          | Quand l'utiliser                       |
+| --------------- | ------------------------------------ | -------------------------------------- |
+| **Global**      | `~/.codex/config.toml`               | Tous les projets partagent le serveur  |
+| **Par projet**  | `<racine-projet>/.codex/config.toml` | Configuration MCP par projet           |
 
-> **Priorité** : la config au niveau du projet remplace la config globale si les deux existent.
+> **Priorité** : la config par projet l'emporte sur la config globale si les deux existent.
 
 ### 2.6 Vérifier la connexion
 
-Après avoir sauvegardé `config.toml`, testez la connectivité :
+Après avoir enregistré `config.toml`, testez la connectivité :
 
 ```bash
 # Doit retourner {"status": "ok", ...}
-curl -s -H "Authorization: Bearer lm_VOTRE_TOKEN_ICI" \
+curl -s -H "Authorization: Bearer lm_YOUR_TOKEN_HERE" \
   https://my.live-mem.mcp.cloud-temple.app/health | jq .
 ```
 
@@ -150,7 +150,7 @@ curl -s -H "Authorization: Bearer lm_VOTRE_TOKEN_ICI" \
 
 ## 📁 Étape 3 — Créer un espace mémoire
 
-Avant que Codex puisse écrire des notes, vous avez besoin d'un **espace mémoire** avec des **rules** qui définissent la structure de la Memory Bank.
+Avant que Codex puisse écrire des notes, il vous faut un **espace mémoire** avec des **rules** qui définissent la structure de la Memory Bank.
 
 ### Via la CLI Live Memory
 
@@ -164,12 +164,12 @@ python scripts/mcp_cli.py space create mon-projet \
 
 Demandez à Codex de créer l'espace via l'outil MCP `space_create` :
 
-> *« Utilise l'outil `space_create` avec `space_id='mon-projet'` et les rules standard Memory Bank (projectbrief, activeContext, progress, techContext, systemPatterns, productContext). »*
+> *« Utilise l'outil `space_create` avec `space_id='mon-projet'` et les rules standards Memory Bank (projectbrief, activeContext, progress, techContext, systemPatterns, productContext). »*
 
-### Modèle de rules standard
+### Template de rules standard
 
 ```markdown
-# Rules Memory Bank
+# Memory Bank Rules
 
 ## Fichiers à maintenir
 
@@ -177,10 +177,10 @@ Demandez à Codex de créer l'espace via l'outil MCP `space_create` :
 Vision, objectifs, périmètre du projet.
 
 ### activeContext.md
-Focus actuel, travail en cours, décisions récentes, prochaines étapes.
+Focus courant, travail en cours, décisions récentes, prochaines étapes.
 
 ### progress.md
-Ce qui fonctionne, ce qui reste à construire, problèmes connus.
+Ce qui marche, ce qui reste à construire, problèmes connus.
 
 ### techContext.md
 Technologies utilisées, configuration, contraintes techniques.
@@ -194,14 +194,14 @@ Pourquoi ce projet existe, problèmes résolus, expérience utilisateur.
 
 ---
 
-## 📝 Étape 4 — Donner des instructions à Codex
+## 📝 Étape 4 — Donner les instructions à Codex
 
-Pour que Codex utilise automatiquement Live Memory, ajoutez des instructions dans un fichier `AGENTS.md` à la racine de votre projet (Codex le charge automatiquement comme instructions au niveau de l'agent).
+Pour que Codex utilise automatiquement Live Memory, ajoutez des instructions dans un fichier `AGENTS.md` à la racine de votre projet (Codex le charge automatiquement comme instructions agent).
 
-### 4.1 Modèle `AGENTS.md` recommandé
+### 4.1 Template `AGENTS.md` recommandé
 
 ```markdown
-# Instructions Agent Codex — Live Memory MCP
+# Instructions agent Codex — Live Memory MCP
 
 Ma mémoire se réinitialise complètement entre les sessions. Je dépends ENTIÈREMENT
 de la Memory Bank pour comprendre le projet et continuer efficacement.
@@ -213,21 +213,21 @@ Ma mémoire persistante est gérée par le serveur MCP **Live Memory** (`my-live
 > **La seule valeur à personnaliser :**
 > - **SPACE** = `mon-projet`  ← Remplacez par votre space_id
 >
-> Toutes les instructions ci-dessous utilisent `{SPACE}`. Le nom de l'agent est auto-détecté depuis le token.
+> Toutes les instructions ci-dessous utilisent `{SPACE}`. Le nom d'agent est auto-détecté depuis le token.
 
-## Au démarrage de CHAQUE tâche (OBLIGATOIRE)
+## Au début de CHAQUE tâche (OBLIGATOIRE)
 
 1. Appeler `space_rules("{SPACE}")` pour lire les rules (structure de la bank)
 2. Appeler `bank_read_all("{SPACE}")` pour charger TOUT le contexte consolidé
 3. Appeler `live_read(space_id="{SPACE}")` pour lire les **notes non consolidées**
 4. Lire attentivement le contenu avant de commencer
-5. Identifier le focus actuel dans `activeContext.md`
+5. Identifier le focus courant dans `activeContext.md`
 
-> ⚠️ Ne JAMAIS commencer à travailler sans avoir lu la bank.
+> ⚠️ NE JAMAIS commencer à travailler sans avoir lu la bank.
 
 ## Pendant le travail
 
-Écrire des notes fréquentes et atomiques avec `live_note` :
+Écrire des notes atomiques fréquentes avec `live_note` :
 
 ```
 live_note(space_id="{SPACE}", category="<catégorie>", content="...")
@@ -241,23 +241,25 @@ live_note(space_id="{SPACE}", category="<catégorie>", content="...")
 bank_consolidate(space_id="{SPACE}")
 ```
 
-## Règles impératives
+> 🔕 `bank_consolidate` est **fire-and-forget** : il retourne un accusé async (`running` / `queued`) avec `next_action="return_to_user_without_polling"`. **Appelez-le une seule fois et rendez la main à l'utilisateur.** Ne surveillez pas et ne pollez pas. `bank_consolidation_status(job_id)` existe uniquement pour des **checks manuels explicites**.
 
-1. **Ne JAMAIS écrire directement dans la bank** — seule la consolidation LLM le fait
-2. **Toujours passer `space_id="{SPACE}"`** dans tous les appels
-3. **Écrire des notes atomiques après chaque étape importante** — 1 note = 1 fait, 1 décision, ou 1 tâche
-4. **Consolider en fin de session** — ne jamais quitter sans consolider
+## Règles obligatoires
+
+1. **NE JAMAIS écrire directement dans la bank** — seule la consolidation LLM le fait
+2. **Toujours passer `space_id="{SPACE}"`** dans chaque appel
+3. **Écrire des notes atomiques après chaque étape significative** — 1 note = 1 fait, 1 décision, ou 1 tâche
+4. **Consolider en fin de session** — appelez `bank_consolidate` une seule fois et rendez la main à l'utilisateur sans poller (pas de boucle automatique sur `bank_consolidation_status`)
 5. **Lire la bank au démarrage** — ne jamais travailler sans contexte
 ```
 
 ### 4.2 Version minimaliste (prompt inline)
 
 ```
-Tu as accès à Live Memory (serveur MCP : my-live-mem).
+Vous avez accès à Live Memory (serveur MCP : my-live-mem).
 - Au démarrage : space_rules("mon-projet"), bank_read_all("mon-projet"), live_read("mon-projet")
 - Pendant le travail : live_note(space_id="mon-projet", category="...", content="...")
-- En fin de session : bank_consolidate(space_id="mon-projet")
-Le nom de l'agent est auto-détecté depuis le token d'authentification.
+- En fin de session : bank_consolidate(space_id="mon-projet") — appeler une seule fois et rendre la main sans poller
+Le nom d'agent est auto-détecté depuis le token d'authentification.
 ```
 
 ---
@@ -265,39 +267,39 @@ Le nom de l'agent est auto-détecté depuis le token d'authentification.
 ## 🔄 Workflow recommandé
 
 ```
-┌────────────────────────────────────────────────────┐
-│  1. DÉMARRAGE                                      │
-│     space_rules("mon-projet")                      │
-│     bank_read_all("mon-projet")                    │
-│     live_read("mon-projet")                        │
-│     → Codex lit les rules + bank + notes live      │
-├────────────────────────────────────────────────────┤
-│  2. TRAVAIL (boucle)                               │
-│     • Codex code, analyse, répond                  │
-│     • live_note("observation", "Tests OK")         │
-│     • live_note("decision", "FastAPI retenu")      │
-│     • live_note("todo", "Ajouter l'auth")          │
-│     • live_note("progress", "API terminée")        │
-├────────────────────────────────────────────────────┤
-│  3. FIN DE SESSION                                 │
-│     bank_consolidate("mon-projet")                 │
-│     → Le LLM synthétise les notes dans la bank     │
-│     → Les notes live sont supprimées après succès  │
-└────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────┐
+│  1. DÉMARRAGE                                  │
+│     space_rules("mon-projet")                  │
+│     bank_read_all("mon-projet")                │
+│     live_read("mon-projet")                    │
+│     → Codex lit rules + bank + notes live      │
+├────────────────────────────────────────────────┤
+│  2. TRAVAIL (boucle)                           │
+│     • Codex code, analyse, répond              │
+│     • live_note("observation", "Tests OK")     │
+│     • live_note("decision", "FastAPI choisi")  │
+│     • live_note("todo", "Ajouter auth")        │
+│     • live_note("progress", "API terminée")    │
+├────────────────────────────────────────────────┤
+│  3. FIN DE SESSION                             │
+│     bank_consolidate("mon-projet")             │
+│     → Le LLM synthétise les notes dans la bank │
+│     → Les notes live sont supprimées si OK     │
+└────────────────────────────────────────────────┘
 ```
 
 ### Fréquence de consolidation
 
-| Situation                   | Recommandation                       |
-| --------------------------- | ------------------------------------ |
-| Session courte (< 10 notes) | Consolider en fin de session         |
-| Session longue (> 20 notes) | Consolider toutes les 15–20 notes    |
-| Changement de sujet         | Consolider avant de changer de sujet |
-| Fin de journée              | Toujours consolider                  |
+| Situation                    | Recommandation                           |
+| ---------------------------- | ---------------------------------------- |
+| Session courte (< 10 notes)  | Consolider en fin de session             |
+| Session longue (> 20 notes)  | Consolider toutes les 15–20 notes        |
+| Changement de contexte       | Consolider avant de changer de sujet     |
+| Fin de journée               | Toujours consolider                      |
 
 ---
 
-## 👥 Multi-agents : Codex + Cline + autres
+## 👥 Multi-agent : Codex + Cline + autres
 
 Live Memory permet à **plusieurs agents** de collaborer sur le même espace mémoire :
 
@@ -305,12 +307,12 @@ Live Memory permet à **plusieurs agents** de collaborer sur le même espace mé
 2. Configurer chaque agent avec son propre token
 3. Tous les agents partagent le même `space_id`
 
-L'identité de l'agent est **automatiquement déduite depuis le token** — aucune spécification manuelle n'est nécessaire.
+L'identité de l'agent est **automatiquement inférée depuis le token** — aucune spécification manuelle nécessaire.
 
-La communication inter-agents se fait **via l'espace partagé** :
+La communication inter-agents passe **par l'espace partagé** :
 
 ```
-Codex  → live_note(category="todo", content="Ajouter la pagination sur /users")
+Codex  → live_note(category="todo", content="Ajouter la pagination à /users")
 Cline  → live_read(category="todo")  ← voit la tâche de Codex
 Cline  → live_note(category="progress", content="Pagination implémentée")
 Codex  → live_read(category="progress")  ← reprend là où Cline s'est arrêté
@@ -318,17 +320,17 @@ Codex  → live_read(category="progress")  ← reprend là où Cline s'est arrê
 
 ---
 
-## 🔍 Dépannage
+## 🔍 Troubleshooting
 
 ### Codex ne voit pas les outils Live Memory
 
 1. Vérifiez que `config.toml` est au bon emplacement et que la syntaxe TOML est valide
-2. Assurez-vous que `enabled = true` est bien présent dans la section `[mcp_servers.my-live-mem]`
+2. Assurez-vous que `enabled = true` est défini dans la section `[mcp_servers.my-live-mem]`
 3. Confirmez que l'URL se termine par `/mcp`
-4. Testez manuellement le token :
+4. Testez le token manuellement :
 
 ```bash
-curl -s -H "Authorization: Bearer lm_VOTRE_TOKEN_ICI" \
+curl -s -H "Authorization: Bearer lm_YOUR_TOKEN_HERE" \
   https://my.live-mem.mcp.cloud-temple.app/health
 ```
 
@@ -338,18 +340,18 @@ curl -s -H "Authorization: Bearer lm_VOTRE_TOKEN_ICI" \
 - Vérifiez la valeur du header : `"Authorization" = "Bearer lm_..."` (notez le préfixe `lm_`)
 - Vérifiez si le token a été révoqué via la console d'administration
 
-### Erreur « Accès refusé à l'espace »
+### Erreur « Access Denied to Space »
 
-Le token est restreint à certains espaces (`space_ids`). Deux solutions :
-- Créer un token sans restriction d'espace
-- Ou ajouter l'espace au token :
+Le token est restreint à certains spaces (`space_ids`). Soit :
+- Créez un token sans restriction de space
+- Soit ajoutez le space au token :
   ```
   admin_update_token(token_hash, space_ids_add="mon-projet")
   ```
 
-### La consolidation est lente ou expire
+### La consolidation est lente ou time-out
 
-La consolidation LLM prend typiquement 30 à 120 secondes. Si Codex expire :
+La consolidation LLM prend typiquement 30–120 secondes. Si Codex time-out :
 
 1. Vérifiez si votre environnement Codex permet de configurer un timeout MCP plus long
 2. Suivez la progression côté serveur dans les logs :
@@ -358,11 +360,11 @@ La consolidation LLM prend typiquement 30 à 120 secondes. Si Codex expire :
 docker compose logs -f live-mem-service --tail 20
 ```
 
-3. Utilisez `bank_consolidate` — il traite les notes par lots de 10 par défaut
+3. Utilisez `bank_consolidate` en plus petits batches (il traite les notes par lots de 10 par défaut)
 
 ### Erreurs de syntaxe TOML
 
-Erreurs courantes dans `config.toml` :
+Erreurs fréquentes dans `config.toml` :
 
 ```toml
 # ✅ CORRECT
@@ -379,13 +381,13 @@ http_headers = { "Authorization" = Bearer lm_abc123 }
 
 ## 📊 Récapitulatif
 
-| Étape     | Action                                                           | Durée      |
-| --------- | ---------------------------------------------------------------- | ---------- |
-| 1         | Obtenir un token (`token create codex-agent`)                    | 1 min      |
-| 2         | Éditer `.codex/config.toml` avec l'URL + le header Authorization | 2 min      |
-| 3         | Créer un espace mémoire (`space_create`)                         | 30 sec     |
-| 4         | Ajouter `AGENTS.md` avec les instructions Memory Bank            | 2 min      |
-| **Total** | **Prêt à utiliser**                                              | **~6 min** |
+| Étape     | Action                                                       | Temps      |
+| --------- | ------------------------------------------------------------ | ---------- |
+| 1         | Obtenir un token (`token create codex-agent`)                | 1 min      |
+| 2         | Éditer `.codex/config.toml` avec URL + header Authorization  | 2 min      |
+| 3         | Créer un espace mémoire (`space_create`)                     | 30 sec     |
+| 4         | Ajouter `AGENTS.md` avec les instructions Memory Bank        | 2 min      |
+| **Total** | **Prêt à l'emploi**                                          | **~6 min** |
 
 ---
 

--- a/CODEX_INTEGRATION.md
+++ b/CODEX_INTEGRATION.md
@@ -241,12 +241,14 @@ live_note(space_id="{SPACE}", category="<category>", content="...")
 bank_consolidate(space_id="{SPACE}")
 ```
 
+> 🔕 `bank_consolidate` is **fire-and-forget**: it returns an async job ack (`running` / `queued`) with `next_action="return_to_user_without_polling"`. **Call it once and return to the user.** Do not watch or poll. `bank_consolidation_status(job_id)` exists for **explicit manual checks only**.
+
 ## Mandatory Rules
 
 1. **NEVER write directly to the bank** — only the LLM consolidation does that
 2. **Always pass `space_id="{SPACE}"`** in every call
 3. **Write atomic notes after each significant step** — 1 note = 1 fact, 1 decision, or 1 task
-4. **Consolidate at session end** — never leave without consolidating
+4. **Consolidate at session end** — call `bank_consolidate` once and return to the user without polling (no automatic `bank_consolidation_status` loop)
 5. **Read the bank at startup** — never work without context
 ```
 
@@ -256,7 +258,7 @@ bank_consolidate(space_id="{SPACE}")
 You have access to Live Memory (MCP server: my-live-mem).
 - At startup: space_rules("my-project"), bank_read_all("my-project"), live_read("my-project")
 - During work: live_note(space_id="my-project", category="...", content="...")
-- At session end: bank_consolidate(space_id="my-project")
+- At session end: bank_consolidate(space_id="my-project") — call once and return without polling
 The agent name is auto-detected from the authentication token.
 ```
 

--- a/DESIGN/live-mem/CONCURRENCY.md
+++ b/DESIGN/live-mem/CONCURRENCY.md
@@ -47,8 +47,10 @@ async def bank_consolidate(space_id: str, agent: str = "") -> dict:
 
 **Behavior**:
 - The MCP call returns quickly with `status="running"` or `status="queued"`
+- The response includes `next_action="return_to_user_without_polling"` and `polling.recommended=false`
+- Caller contract: call once, do not watch/poll unless explicitly requested
 - A queued request is processed FIFO for the same `space_id`
-- Job status is observable via `bank_consolidation_status(job_id)` and `space_info`
+- Job status is observable via `bank_consolidation_status(job_id)` and `space_info`, but `bank_consolidation_status` is a manual-only explicit check, not an automatic polling loop
 - Two different spaces can be consolidated in parallel (independent locks)
 - PR 1 queue durability is `in_memory_best_effort`: jobs are not persisted across process restart
 
@@ -154,21 +156,23 @@ T+0s: Agent C → live_note("todo", "Write tests")              → PUT S3: note
 
 ```
 T+0s:  Agent A → bank_consolidate("project-alpha", agent="agent-A")
-       → Lock acquired ✅, consolidation starts (takes 30s)
+       → Async job accepted: {"status": "running", "job_id": "..."}
+       → Agent A returns to the user without polling
 
 T+5s:  Agent B → bank_consolidate("project-alpha", agent="agent-B")
-       → Lock already held → immediate return {"status": "conflict"} ⚡
+       → Async job accepted: {"status": "queued", "job_id": "...", "queue_position": 2}
+       → Agent B returns to the user without polling
 
 T+30s: Agent A → consolidation complete, lock released ✅
-T+31s: Agent B → bank_consolidate("project-alpha", agent="agent-B")
-       → Lock acquired ✅, consolidation starts
+       → Worker starts Agent B's queued job automatically
 ```
 
 ### Scenario 3: Agent writes during a consolidation
 
 ```
 T+0s:  Agent A → bank_consolidate("project-alpha", agent="agent-A")
-       → Lock acquired, reads agent-A's live notes
+       → Async job accepted; background worker acquires the lock
+       → Worker reads agent-A's live notes when the job starts
 
 T+5s:  Agent B → live_note("observation", "New finding")
        → PUT S3: note_new.md ✅ (no lock needed)
@@ -184,7 +188,7 @@ T+30s: Agent A → consolidation complete
 
 ```
 T+0s:  Agent A → bank_consolidate("project-alpha")
-       → Consolidation lock acquired
+       → Async job accepted; background worker may hold the consolidation lock
 
 T+5s:  Agent B → graph_push("project-alpha")
        → No lock needed (read-only access to bank + MCP Streamable HTTP call)
@@ -200,7 +204,8 @@ T+5s:  Agent B → graph_push("project-alpha")
 | `live_note` | 50-100ms (1 PUT S3) | No | None |
 | `live_read` (50 notes) | 200-500ms (1 LIST + N GETs) | No | None |
 | `bank_read_all` (6 files) | 100-300ms (1 LIST + 6 GETs) | No | None |
-| `bank_consolidate` | 20-60s (LLM + S3 I/O) | Yes (per space) | Blocks other consolidations for the same space |
+| `bank_consolidate` enqueue | ~50ms | No | Returns `running`/`queued`; caller must not auto-poll |
+| Background consolidation job | 20-60s (LLM + S3 I/O) | Yes (per space) | Serializes bank mutation for the same space |
 | `graph_push` (6 files) | 60-180s (MCP Streamable HTTP) | No | None |
 | `admin_create_token` | 100-200ms (1 GET + 1 PUT S3) | Yes (tokens) | Short serialization |
 

--- a/DESIGN/live-mem/CONSOLIDATION_LLM.md
+++ b/DESIGN/live-mem/CONSOLIDATION_LLM.md
@@ -59,7 +59,7 @@ _synthesis.md (previous)
 
 ## 2. The `agent` Parameter (v0.2.0+)
 
-The `agent` parameter of `bank_consolidate` controls note filtering. Since issue #20, `bank_consolidate` enqueues a background job and returns immediately; notes are collected at job execution time, not at enqueue time.
+The `agent` parameter of `bank_consolidate` controls note filtering. Since issue #20, `bank_consolidate` enqueues a background job and returns immediately; notes are collected at job execution time, not at enqueue time. The caller contract is call once and return to the user; do not watch/poll unless an explicit status check is requested via `bank_consolidation_status`.
 
 | Value | Behavior | Permission |
 |-------|----------|------------|
@@ -233,7 +233,9 @@ consolidate(space_id, agent):
 - **Single meta update**: `consolidation_count` incremented by 1 (not N), `total_notes_processed` accumulated
 - **Sanitization**: `_sanitize_filename()` applied on each filename before S3 write
 
-### Enriched Metrics (`bank_consolidate` response)
+### Enriched Metrics (background job result)
+
+These fields are available in the completed job result when an explicit status check is requested. They are not a reason to poll automatically after `bank_consolidate`.
 
 ```json
 {

--- a/DESIGN/live-mem/MCP_TOOLS_SPEC.md
+++ b/DESIGN/live-mem/MCP_TOOLS_SPEC.md
@@ -294,6 +294,8 @@ async def bank_list(space_id: str) -> dict:
 
 Enqueues LLM consolidation: returns immediately with a job acknowledgement. The background worker reads live notes, rules, and the current bank when the job actually runs, then uses the LLM to produce updated bank files.
 
+Caller contract: call `bank_consolidate` once at session end, then return to the user. Do not wait for completion and do not watch/poll automatically unless the user explicitly asks for a status check.
+
 ```python
 @mcp.tool()
 async def bank_consolidate(
@@ -312,6 +314,8 @@ async def bank_consolidate(
 - Only one consolidation mutates a space's bank at a time (global per-space lock)
 - Same-space requests are serialized FIFO instead of rejected with `conflict`
 - The PR 1 queue is in-memory only (`guarantee="in_memory_best_effort"`)
+- The response explicitly sets `next_action="return_to_user_without_polling"`
+- `polling.recommended=false`; `bank_consolidation_status` is manual-only for explicit status checks
 - If no live notes exist, the background job result is `{"status": "ok", "notes_processed": 0, "message": "No new notes to consolidate"}`
 - Configurable timeout (`CONSOLIDATION_TIMEOUT`, default 600s)
 
@@ -325,7 +329,14 @@ async def bank_consolidate(
   "agent": "cline-dev",
   "requested_by": "cline-dev",
   "queue_position": 1,
-  "guarantee": "in_memory_best_effort"
+  "guarantee": "in_memory_best_effort",
+  "next_action": "return_to_user_without_polling",
+  "polling": {
+    "recommended": false,
+    "mode": "manual_only",
+    "status_tool": "bank_consolidation_status",
+    "instruction": "Do not wait for completion or poll automatically. Store the job_id only if an explicit status check is needed."
+  }
 }
 ```
 
@@ -338,7 +349,7 @@ Returns the in-memory status for a consolidation job.
 async def bank_consolidation_status(job_id: str) -> dict:
 ```
 
-Returns `queued`, `running`, `succeeded`, `failed`, or `not_found`. The caller must have read access to the job's `space_id`.
+Returns `queued`, `running`, `succeeded`, `failed`, or `not_found`. The caller must have read access to the job's `space_id`. This tool is for explicit manual status checks only; clients must not call it automatically after every `bank_consolidate`.
 
 ---
 

--- a/FAQ.fr.md
+++ b/FAQ.fr.md
@@ -1,42 +1,44 @@
 # ❓ FAQ — Live Memory
 
+🇬🇧 [English version](FAQ.md)
+
 ---
 
 ## Concepts généraux
 
 ### Quelle est la différence entre Live Memory et graph-memory ?
 
-|                  | **Live Memory**                  | **graph-memory**                   |
-| ---------------- | -------------------------------- | ---------------------------------- |
-| **Type**         | Mémoire de travail               | Mémoire long terme                 |
-| **Données**      | Notes live + bank Markdown       | Knowledge Graph + embeddings       |
-| **Stockage**     | S3 (fichiers)                    | Neo4j + Qdrant                     |
-| **Intelligence** | LLM consolide les notes en bank  | RAG vectoriel pour la recherche    |
-| **Analogie**     | Tableau blanc → Cahier de projet | Bibliothèque → Moteur de recherche |
+|                  | **Live Memory**                            | **graph-memory**                   |
+| ---------------- | ------------------------------------------ | ---------------------------------- |
+| **Type**         | Mémoire de travail                         | Mémoire long terme                 |
+| **Données**      | Notes live + bank Markdown                 | Knowledge Graph + embeddings       |
+| **Stockage**     | S3 (fichiers)                              | Neo4j + Qdrant                     |
+| **Intelligence** | Le LLM consolide les notes dans la bank    | RAG vectoriel pour la recherche    |
+| **Analogie**     | Tableau blanc → carnet de projet           | Bibliothèque → moteur de recherche |
 
-Les deux sont complémentaires. Live Memory est pour le travail quotidien, graph-memory pour la connaissance persistante.
+Les deux sont complémentaires. Live Memory pour le travail quotidien, graph-memory pour la connaissance persistante.
 
-### C'est quoi un "espace" (space) ?
+### Qu'est-ce qu'un « space » ?
 
 Un espace mémoire isolé = un projet. Il contient :
-- **Rules** : template Markdown qui définit la structure de la bank
-- **Notes live** : observations, décisions, todos... des agents (append-only)
+- **Rules** : template Markdown définissant la structure de la bank
+- **Notes live** : observations, décisions, todos... émises par les agents (append-only)
 - **Bank** : fichiers Markdown consolidés par le LLM selon les rules
 
-### C'est quoi les "rules" ?
+### Que sont les « rules » ?
 
-Les rules définissent la structure de la Memory Bank. Elles sont écrites en Markdown à la création de l'espace et sont **immuables**. Le LLM les utilise pour créer et maintenir les fichiers bank.
+Les rules définissent la structure de la Memory Bank. Elles sont écrites en Markdown à la création du space et sont **immuables**. Le LLM s'en sert pour créer et maintenir les fichiers de la bank.
 
-Exemple de rules (standard Memory Bank) :
+Exemple de rules (Memory Bank standard) :
 ```markdown
 ### projectbrief.md
 Objectifs, périmètre, critères de succès.
 
 ### activeContext.md
-Focus actuel, changements récents, prochaines étapes.
+Focus courant, changements récents, prochaines étapes.
 
 ### progress.md
-Ce qui fonctionne, ce qui reste, problèmes connus.
+Ce qui marche, ce qui reste, problèmes connus.
 ```
 
 ---
@@ -45,14 +47,14 @@ Ce qui fonctionne, ce qui reste, problèmes connus.
 
 ### Quelle est la relation entre un token et un agent ?
 
-Depuis **v0.8.1**, chaque token **est** un agent. Le `client_name` du token est automatiquement utilisé comme identité de l'agent — il n'y a plus de paramètre `agent=` dans `live_note`.
+Depuis la **v0.8.1**, chaque token **est** un agent. Le `client_name` du token est automatiquement utilisé comme identité de l'agent — il n'y a pas de paramètre `agent=` dans `live_note`.
 
-|                        | **Token = Agent**                             |
-| ---------------------- | --------------------------------------------- |
-| **Rôle**               | Authentification **et** identité              |
-| **Exemple**            | Token `cline-dev` → agent `cline-dev`         |
-| **Partageable ?**      | Non — 1 token = 1 agent = 1 identité          |
-| **Où est-il fourni ?** | Header `Authorization: Bearer` (auto-détecté) |
+|                        | **Token = Agent**                                 |
+| ---------------------- | ------------------------------------------------- |
+| **Rôle**               | Authentification **et** identité                  |
+| **Exemple**            | Token `cline-dev` → agent `cline-dev`             |
+| **Partageable ?**      | Non — 1 token = 1 agent = 1 identité              |
+| **Où le fournir ?**    | Header `Authorization: Bearer` (auto-détecté)     |
 
 **Pourquoi ce changement ?** L'ancien modèle (Token ≠ Agent) permettait de passer un nom d'agent libre, ce qui causait des notes orphelines (agent non reconnu à la consolidation), de l'usurpation d'identité, et de l'éparpillement.
 
@@ -64,59 +66,59 @@ Oui ! `live_read(space_id="mon-projet")` retourne les notes de TOUS les agents. 
 
 ## Permissions et sécurité
 
-### Quels sont les niveaux de permission ?
+### Quels sont les niveaux de permissions ?
 
-Depuis **v1.5.0**, il y a 4 niveaux **hiérarchiques et cumulatifs** :
+Depuis la **v1.5.0**, il y a 4 niveaux **hiérarchiques et cumulatifs** :
 
-| Niveau     | Inclut                | Accès                                                                                                                                             |
-| ---------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **read**   | —                     | Lecture : `bank_read`, `live_read`, `space_info`, `backup_list`, etc.                                                                             |
-| **write**  | read                  | Écriture : `live_note`, `bank_consolidate`, `space_create`, etc.                                                                                  |
+| Niveau     | Inclut                | Accès                                                                                                                                            |
+| ---------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **read**   | —                     | Lecture : `bank_read`, `live_read`, `space_info`, `backup_list`, etc.                                                                            |
+| **write**  | read                  | Écriture : `live_note`, `bank_consolidate`, `space_create`, etc.                                                                                 |
 | **manage** | write + read          | Maintenance : `bank_write`, `bank_delete`, `bank_repair`, `bank_compact`, `space_delete`, `space_update_rules`, `backup_restore`, `backup_delete` |
-| **admin**  | manage + write + read | Administration : `admin_create_token`, `admin_gc_notes`, etc.                                                                                     |
+| **admin**  | manage + write + read | Administration : `admin_create_token`, `admin_gc_notes`, etc.                                                                                    |
 
-Un token `write` ne peut **pas** modifier directement les fichiers bank ni supprimer des espaces — il faut `manage` ou `admin`.
+Un token `write` **ne peut pas** modifier directement les fichiers bank ni supprimer des spaces — il faut `manage` ou `admin`.
 
 ### Pourquoi les permissions sont-elles cumulatives ?
 
-Chaque niveau **inclut automatiquement** tous les niveaux inférieurs. Il n'est pas nécessaire de spécifier `read,write` si vous donnez `manage` — `manage` contient déjà `write` et `read`.
+Chaque niveau **inclut automatiquement** tous les niveaux inférieurs. Inutile de préciser `read,write` si vous accordez `manage` — `manage` contient déjà `write` et `read`.
 
 ```
 read < write < manage < admin
 ```
 
-En pratique, lors de la création ou mise à jour d'un token, spécifiez toujours la **liste complète** des permissions (ex : `"read,write,manage"`), car le champ `permissions` est une **liste explicite** stockée sur S3, pas un niveau unique. Le serveur vérifie la présence du niveau requis dans cette liste.
+En pratique, lors de la création ou de la mise à jour d'un token, indiquez toujours la **liste complète** des permissions (ex. : `"read,write,manage"`), car le champ `permissions` est une **liste explicite** stockée sur S3, pas un niveau unique. Le serveur vérifie la présence du niveau requis dans cette liste.
 
-### Quel type de token créer selon mon cas d'usage ?
+### Quel type de token créer pour mon cas d'usage ?
 
 | Cas d'usage | Permissions recommandées | `space_ids` |
 | --- | --- | --- |
-| Agent IA en mode travail (Cline, Claude) | `read,write` | Espaces du projet |
-| Agent IA + maintenance (compaction, repair) | `read,write,manage` | Espaces du projet |
-| Opérateur humain (maintenance multi-projets) | `read,write,manage` | Tous les espaces concernés |
-| Administrateur | `read,write,manage,admin` | Vide (admin voit tout) |
-| Lecteur / dashboard de monitoring | `read` | Espaces à surveiller |
+| Agent IA en mode travail (Cline, Claude) | `read,write` | Spaces du projet |
+| Agent IA + maintenance (compaction, repair) | `read,write,manage` | Spaces du projet |
+| Opérateur humain (maintenance multi-projets) | `read,write,manage` | Tous les spaces concernés |
+| Administrateur | `read,write,manage,admin` | Vide (l'admin voit tout) |
+| Lecteur / dashboard de monitoring | `read` | Spaces à monitorer |
 
-### Comment restreindre un token à certains espaces ?
+### Comment restreindre un token à des spaces spécifiques ?
 
-Chaque token a un champ `space_ids` qui liste les espaces autorisés :
+Chaque token a un champ `space_ids` listant les spaces autorisés :
 
 ```bash
-# Restreindre KSE à 3 espaces
+# Restreindre KSE à 3 spaces
 python scripts/mcp_cli.py token update sha256:363... -p "read,write" -s "live-mem,graph-mem,mcp-office"
 ```
 
 **Sémantique de `space_ids` (v1.5.0+)** :
-- `space_ids = ["a", "b"]` → accès uniquement à ces espaces
-- `space_ids = []` pour un **non-admin** → **aucun accès** (changed in v1.5.0, avant = tout)
+- `space_ids = ["a", "b"]` → accès uniquement à ces spaces
+- `space_ids = []` pour un **non-admin** → **aucun accès** (changement en v1.5.0, valait « tous » avant)
 - `space_ids = []` pour un **admin** → accès à **tout** (inchangé)
 
 À la **création** d'un token via `admin_create_token`, vous pouvez utiliser :
-- `space_ids=""` (défaut) → token "muet" (aucun accès aux espaces existants). La réponse contient un champ `warning_no_access` pour vous le signaler explicitement.
+- `space_ids=""` (par défaut) → token « muet » (aucun accès aux spaces existants). La réponse contient un champ `warning_no_access` pour le signaler explicitement.
 - `space_ids="a,b,c"` → liste explicite.
-- `space_ids="*"` ou `space_ids="all"` → **snapshot** de tous les espaces existants au moment de la création (pas les futurs spaces, c'est volontaire pour rester aligné avec la sémantique stricte v1.5.0).
+- `space_ids="*"` ou `space_ids="all"` → **snapshot** de tous les spaces existants à la création (pas les futurs spaces — volontaire pour rester aligné sur la sémantique stricte v1.5.0).
 
-### Le hash retourné par `admin_list_tokens` contient `sha256:` — faut-il le passer tel quel ?
+### Le hash retourné par `admin_list_tokens` contient `sha256:` — dois-je le passer tel quel ?
 
 Depuis l'issue #11, **les deux formes sont acceptées** par `admin_revoke_token`, `admin_delete_token` et `admin_update_token` :
 ```bash
@@ -124,11 +126,11 @@ admin_update_token(token_hash="sha256:f172084ef03...", space_ids="x")  # OK
 admin_update_token(token_hash="f172084ef03...", space_ids="x")          # OK aussi
 ```
 
-Le minimum reste 16 caractères hex (8 octets de hash) pour éviter les collisions accidentelles.
+Le minimum reste de 16 caractères hex (8 octets de hash) pour éviter les collisions accidentelles.
 
 ### Que se passe-t-il quand un token crée un nouveau space ?
 
-Le space est **automatiquement ajouté** au `space_ids` du token (via `add_space_to_token()`). Ainsi un token restreint à `["projet-a"]` qui crée `projet-b` se retrouve avec `["projet-a", "projet-b"]`. Pas de deadlock UX.
+Le space est **automatiquement ajouté** au `space_ids` du token (via `add_space_to_token()`). Donc un token restreint à `["project-a"]` qui crée `project-b` se retrouve avec `["project-a", "project-b"]`. Pas de deadlock UX.
 
 ### Comment ajouter la permission `manage` à un token ?
 
@@ -136,22 +138,22 @@ Le space est **automatiquement ajouté** au `space_ids` du token (via `add_space
 python scripts/mcp_cli.py token update sha256:xxx -p "read,write,manage"
 ```
 
-⚠️ La mise à jour des permissions **remplace** la liste complète — il faut toujours inclure `read,write` en plus de `manage`.
+⚠️ La mise à jour de permissions **remplace** la liste complète — incluez toujours `read,write` en plus de `manage`.
 
 ### Que s'est-il passé lors de la migration v1.5.0 ?
 
-Avant v1.5.0, `space_ids=[]` signifiait "accès à tout". Depuis v1.5.0, ça signifie "aucun accès" (pour les non-admin).
+Avant la v1.5.0, `space_ids=[]` signifiait « accès à tout ». Depuis la v1.5.0, cela signifie « aucun accès » (pour les tokens non-admin).
 
-**Migration automatique au démarrage** : tous les tokens non-admin ayant `space_ids=[]` se sont vu assigner automatiquement la liste de **tous les espaces existants**. Aucune perte d'accès.
+**Migration automatique au démarrage** : tous les tokens non-admin avec `space_ids=[]` ont été automatiquement réassignés à la liste de **tous les spaces existants**. Aucune perte d'accès.
 
-### Puis-je donner les droits admin à un token ?
+### Puis-je donner des droits admin à un token ?
 
-Oui, mais avec prudence :
+Oui, avec prudence :
 ```bash
 python scripts/mcp_cli.py token update sha256:xxx -p "read,write,manage,admin"
 ```
 
-Un token admin peut gérer les tokens des autres, consolider les notes de tous les agents, et exécuter le GC. Il voit tous les espaces quel que soit son `space_ids`.
+Un token admin peut gérer les autres tokens, consolider les notes de tous les agents et lancer le GC. Il voit tous les spaces indépendamment de son `space_ids`.
 
 ---
 
@@ -159,22 +161,23 @@ Un token admin peut gérer les tokens des autres, consolider les notes de tous l
 
 ### Comment fonctionne la consolidation ?
 
-1. Le LLM (qwen3.5:27b) lit les **rules**, la **bank actuelle**, la **synthèse précédente**, et les **notes live**
+1. Le LLM lit les **rules**, la **bank actuelle**, la **synthèse précédente** et les **notes live**
 2. Il produit des fichiers bank mis à jour (Markdown pur)
 3. Les notes consolidées sont **supprimées** de `live/`
 4. Une synthèse résiduelle est sauvegardée
 
 ### Que se passe-t-il si 2 agents consolident en même temps ?
 
-Un `asyncio.Lock` par espace empêche les consolidations simultanées :
-- Le premier agent acquiert le lock → consolidation LLM (15-30s)
-- Le second reçoit `{"status": "conflict"}` → doit réessayer
+Un `asyncio.Lock` par space empêche les consolidations simultanées :
+- La première requête est acceptée comme un job async avec `{"status": "running"}` et un `job_id`
+- La seconde reçoit `{"status": "queued"}` avec un `job_id` et une position dans la file
+- Appelez `bank_consolidate` une seule fois en fin de session et rendez la main à l'utilisateur ; ne surveillez pas et ne pollez pas tant qu'un check de statut explicite n'est pas demandé
 
 C'est voulu : les deux agents écrivent dans les mêmes fichiers bank. La consolidation séquentielle permet à chaque agent de voir le travail du précédent.
 
 ### Puis-je consolider les notes de TOUS les agents d'un coup ?
 
-Oui ! `bank_consolidate(space_id="mon-projet")` sans paramètre `agent=` consolide toutes les notes de tous les agents en une seule fois.
+Oui ! `bank_consolidate(space_id="mon-projet")` sans paramètre `agent=` consolide toutes les notes de tous les agents en une seule passe.
 
 ⚠️ **Permissions** : consolider les notes d'un autre agent ou de tous les agents nécessite un token **manage** (ou admin). Un token write ne peut consolider que ses propres notes (`agent="mon-nom"`).
 
@@ -186,7 +189,7 @@ Elles sont **supprimées** de `live/`. Leur contenu est intégré dans les fichi
 
 Depuis la **v1.9.0**, le consolidateur intègre **7 règles anti-hallucination** dans son prompt système :
 
-1. **Attribution stricte aux sources** — tout fait dans la bank DOIT provenir d'une note. Si une section n'a pas de source, elle reste vide ou marquée "À définir".
+1. **Attribution stricte aux sources** — tout fait dans la bank DOIT provenir d'une note. Si une section n'a pas de source, elle reste vide ou marquée « À définir ».
 2. **Préservation du vocabulaire métier** — les termes spécifiques au projet sont utilisés verbatim, jamais ré-interprétés via les priors du LLM.
 3. **Gating des métriques** — les chiffres n'apparaissent que s'ils sont explicitement sourcés dans une note.
 4. **Pas de structure inventée** — les arborescences de fichiers ne sont PAS générées si les notes ne les décrivent pas.
@@ -222,7 +225,7 @@ Oui ! Depuis la **v1.8.1**, définissez `PROXY_URL` dans `.env` :
 PROXY_URL=http://10.0.0.1:3128
 ```
 
-Cela route le trafic S3 (boto3) et LLM (httpx) via le proxy. C'est une **variable custom** (pas `HTTP_PROXY`) pour ne pas affecter les autres bibliothèques Python. Les connexions Graph Memory ne sont pas supportées via le proxy.
+Cela route le trafic S3 (boto3) et LLM (httpx) à travers le proxy. C'est une **variable maison** (pas `HTTP_PROXY`) pour éviter d'affecter d'autres bibliothèques Python. Les connexions Graph Memory ne sont pas supportées via le proxy.
 
 ---
 
@@ -230,7 +233,7 @@ Cela route le trafic S3 (boto3) et LLM (httpx) via le proxy. C'est une **variabl
 
 ### Pourquoi un Garbage Collector ?
 
-Si un agent écrit des notes mais ne consolide jamais (crash, suppression, oubli), les notes s'accumulent sans fin dans `live/`. Le GC identifie et traite ces notes orphelines.
+Si un agent écrit des notes mais ne consolide jamais (crash, suppression, oubli), les notes s'accumulent indéfiniment dans `live/`. Le GC identifie et traite ces notes orphelines.
 
 ### Comment fonctionne le GC ?
 
@@ -239,10 +242,10 @@ Si un agent écrit des notes mais ne consolide jamais (crash, suppression, oubli
 | Mode              | Paramètres                       | Action                                                                 |
 | ----------------- | -------------------------------- | ---------------------------------------------------------------------- |
 | **Dry-run**       | `confirm=False` (défaut)         | Scanne et rapporte                                                     |
-| **Consolidation** | `confirm=True`                   | Consolide les notes dans la bank via LLM + ajoute une notice "⚠️ GC" |
+| **Consolidation** | `confirm=True`                   | Consolide les notes dans la bank via LLM + ajoute un avertissement « ⚠️ GC » |
 | **Suppression**   | `confirm=True, delete_only=True` | Supprime sans consolider (perte de données)                            |
 
-Par défaut, le GC **consolide** (ne supprime pas) pour ne pas perdre de données.
+Par défaut, le GC **consolide** (ne supprime pas) pour éviter la perte de données.
 
 ### Le GC laisse-t-il une trace dans la bank ?
 
@@ -253,40 +256,35 @@ Le GC a détecté X notes orphelines de l'agent 'nom-agent' (> 7 jours).
 Ces notes n'ont jamais été consolidées par l'agent.
 ```
 
-Le LLM voit cette note et l'intègre dans la bank, assurant la traçabilité.
+Le LLM voit cette note et l'intègre à la bank, assurant la traçabilité.
 
 ---
 
 ## Docker et déploiement
 
-### Comment tester en local ?
+### Comment tester localement ?
 
 ```bash
 # 1. Configurer l'environnement
 cp .env.example .env
 nano .env  # Remplir S3, LLMaaS, ADMIN_BOOTSTRAP_KEY
 
-# 2. Lancer le stack
+# 2. Démarrer la stack
 docker compose build
 docker compose up -d
 
 # 3. Tester
-python scripts/test_recette.py           # Recette simple
-python scripts/test_multi_agents.py      # Multi-agents
-python scripts/test_gc.py                # Garbage Collector
+python scripts/test_recette.py           # Recette de base
+python scripts/test_hallucination.py     # Anti-hallucination (Issue #17)
 ```
 
 ### Comment fonctionne le WAF ?
 
-Caddy + Coraza (OWASP CRS) protège contre les injections, XSS, etc. Les routes MCP (SSE + messages) passent **sans** WAF (authentifiées par token côté serveur). Les autres routes passent par le WAF.
-
-### Pourquoi les routes SSE ne passent pas par le WAF ?
-
-Coraza bufférise les réponses pour les inspecter, ce qui est **incompatible** avec le streaming SSE (connexions longues, flux continu). L'authentification est gérée côté serveur MCP.
+Caddy + Coraza (OWASP CRS) protège contre les injections, XSS, etc. Les routes MCP (Streamable HTTP) sont authentifiées par token côté serveur. Les autres routes passent par le WAF.
 
 ### Comment déployer en production ?
 
-1. Mettre `SITE_ADDRESS=mon-domaine.com` dans `.env`
+1. Définir `SITE_ADDRESS=mon-domaine.com` dans `.env`
 2. Exposer les ports 80+443 dans docker-compose.yml
 3. Caddy obtient automatiquement un certificat Let's Encrypt
 4. Voir [DEPLOIEMENT_PRODUCTION.md](DESIGN/live-mem/DEPLOIEMENT_PRODUCTION.md) pour les détails
@@ -297,10 +295,10 @@ Coraza bufférise les réponses pour les inspecter, ce qui est **incompatible** 
 
 ### Pourquoi S3 et pas une base de données ?
 
-- Simplicité : pas de schéma, pas de migrations, pas de serveur DB
-- Portabilité : tout est fichier Markdown/JSON
+- Simplicité : pas de schéma, pas de migration, pas de serveur DB
+- Portabilité : tout est fichiers Markdown/JSON
 - Scalabilité : S3 gère des milliards d'objets
-- Coût : stockage S3 très bon marché
+- Coût : le stockage S3 est très abordable
 
 ### Pourquoi deux clients S3 (SigV2 + SigV4) ?
 
@@ -316,7 +314,7 @@ Oui ! Configurez `S3_ENDPOINT_URL` et les credentials. Le dual SigV2/V4 n'est n�
 
 ---
 
-## CLI et Shell
+## CLI et shell
 
 ### Comment configurer la CLI ?
 
@@ -332,26 +330,26 @@ python scripts/mcp_cli.py health
 python scripts/mcp_cli.py --url http://mon-serveur:8080 --token lm_xxx health
 
 # 3. Automatique (lit .env)
-python scripts/mcp_cli.py health   # URL défaut 8080, token depuis .env
+python scripts/mcp_cli.py health   # URL par défaut 8080, token depuis .env
 ```
 
-### Comment avoir l'aide sur une commande ?
+### Comment obtenir l'aide sur une commande ?
 
 ```bash
-# CLI Click (--help natif)
+# CLI Click (aide native --help)
 python scripts/mcp_cli.py space --help
 python scripts/mcp_cli.py bank consolidate --help
 
 # Shell interactif
 live-mem> help           # aide globale
-live-mem> help space     # sous-commandes de space
+live-mem> help space     # sous-commandes space
 live-mem> space          # idem
-live-mem> help bank      # sous-commandes de bank
+live-mem> help bank      # sous-commandes bank
 ```
 
-### Puis-je utiliser la CLI en mode JSON pour le scripting ?
+### Puis-je utiliser la CLI en mode JSON pour scripter ?
 
-Oui ! Ajoutez `--json` (CLI) ou `--json` (shell) à n'importe quelle commande :
+Oui ! Ajoutez `--json` à n'importe quelle commande :
 
 ```bash
 python scripts/mcp_cli.py space list --json | jq '.spaces[].space_id'
@@ -359,32 +357,32 @@ python scripts/mcp_cli.py space list --json | jq '.spaces[].space_id'
 
 ---
 
-## Troubleshooting — Problèmes courants
+## Troubleshooting — problèmes fréquents
 
-### J'ai un 403 sur tous les espaces
+### Je reçois un 403 sur tous les spaces
 
-**Cause la plus fréquente** : votre token a `space_ids=[]` (aucun accès). Depuis v1.5.0, un token non-admin sans `space_ids` ne peut accéder à rien.
+**Cause la plus fréquente** : votre token a `space_ids=[]` (aucun accès). Depuis la v1.5.0, un token non-admin sans `space_ids` ne peut accéder à rien.
 
 **Diagnostic** :
 ```bash
 python scripts/mcp_cli.py token list --json | jq '.tokens[] | select(.name=="mon-token") | .space_ids'
 ```
 
-**Solution** : demander à un admin de mettre à jour vos espaces :
+**Solution** : demandez à un admin de mettre à jour vos spaces :
 ```bash
-python scripts/mcp_cli.py token update sha256:xxx -s "espace-a,espace-b"
+python scripts/mcp_cli.py token update sha256:xxx -s "space-a,space-b"
 ```
 
 ### Mon token `manage` ne peut rien faire
 
-Un token `manage` sans `space_ids` est un "mainteneur sans rien à maintenir". Il peut uniquement créer de nouveaux espaces (qui seront auto-ajoutés à ses `space_ids`).
+Un token `manage` sans `space_ids` est un « mainteneur sans rien à maintenir ». Il peut seulement créer de nouveaux spaces (qui sont auto-ajoutés à son `space_ids`).
 
-**Solution** : ajouter les espaces à gérer :
+**Solution** : ajouter des spaces à gérer :
 ```bash
-python scripts/mcp_cli.py token update sha256:xxx -s "espace-a,espace-b"
+python scripts/mcp_cli.py token update sha256:xxx -s "space-a,space-b"
 ```
 
-### La consolidation échoue avec "LLM returned invalid JSON"
+### La consolidation échoue avec « LLM returned invalid JSON »
 
 Cause probable : la bank est trop volumineuse. Le LLM a un context window limité et peut échouer sur les réponses JSON longues.
 
@@ -393,11 +391,11 @@ Cause probable : la bank est trop volumineuse. Le LLM a un context window limit�
 2. Vérifier les tailles : `bank_list mon-espace` — si un fichier dépasse 15 KB, c'est un candidat à la compaction
 3. Relancer la consolidation après compaction
 
-### `bank_consolidate` retourne "conflict"
+### `bank_consolidate` retourne « queued »
 
-Un autre agent (ou vous-même dans un autre terminal) est en train de consolider le même espace. Le lock `asyncio` protège contre les écritures concurrentes.
+Un autre agent (ou vous-même dans un autre terminal) consolide le même space. Votre requête a été acceptée et s'exécutera après les jobs précédents sur ce space.
 
-**Solution** : attendre 15-30 secondes et réessayer.
+**Solution** : rendez la main à l'utilisateur sans poller. Conservez le `job_id` retourné uniquement si un check de statut explicite est nécessaire plus tard. `bank_consolidation_status(job_id)` est manuel uniquement ; ne le pollez pas automatiquement.
 
 ### Je ne retrouve plus mes notes après consolidation
 
@@ -415,14 +413,15 @@ Pas de limite théorique. Chaque note = 1 fichier S3 (~200-500 octets). La conso
 
 ### Quelle est la latence ?
 
-| Opération                     | Latence typique |
-| ----------------------------- | --------------- |
-| `live_note` (écriture)        | ~50ms           |
-| `live_read` (lecture)         | ~100ms          |
-| `bank_consolidate` (12 notes) | ~15-30s         |
-| `bank_read_all` (6 fichiers)  | ~200ms          |
-| `system_health`               | ~500ms          |
+| Opération                              | Latence typique |
+| -------------------------------------- | --------------- |
+| `live_note` (écriture)                 | ~50ms           |
+| `live_read` (lecture)                  | ~100ms          |
+| `bank_consolidate` enqueue             | ~50ms           |
+| Consolidation en arrière-plan (12 notes) | ~15-30s       |
+| `bank_read_all` (6 fichiers)           | ~200ms          |
+| `system_health`                        | ~500ms          |
 
 ### Combien d'agents simultanés ?
 
-Pas de limite sur le nombre d'agents écrivant en parallèle (append-only, zéro conflit). La consolidation est séquentielle par espace (1 à la fois).
+Pas de limite sur le nombre d'agents écrivant en parallèle (append-only, zéro conflit). La consolidation est sérialisée FIFO par space (1 job mute la bank d'un space à la fois). `bank_consolidate` est un handoff async en « call-once » ; ne surveillez pas et ne pollez pas sauf demande explicite.

--- a/FAQ.md
+++ b/FAQ.md
@@ -169,8 +169,9 @@ An admin token can manage other tokens, consolidate all agents' notes, and run t
 ### What happens if 2 agents consolidate at the same time?
 
 An `asyncio.Lock` per space prevents simultaneous consolidations:
-- The first agent acquires the lock → LLM consolidation (15-30s)
+- The first request is accepted as an async job with `{"status": "running"}` and a `job_id`
 - The second receives `{"status": "queued"}` with a `job_id` and queue position
+- Call `bank_consolidate` once at session end and return to the user; do not watch/poll unless an explicit status check is requested
 
 This is intentional: both agents write to the same bank files. Sequential consolidation lets each agent see the previous one's work.
 
@@ -394,7 +395,7 @@ Probable cause: the bank is too large. The LLM has a limited context window and 
 
 Another agent (or yourself in another terminal) is consolidating the same space. Your request was accepted and will run after earlier same-space jobs.
 
-**Solution**: keep the returned `job_id` and call `bank_consolidation_status(job_id)`, or inspect `space_info` for the queue summary.
+**Solution**: return to the user without polling. Keep the returned `job_id` only if an explicit status check is needed later. `bank_consolidation_status(job_id)` is manual-only; do not watch/poll automatically.
 
 ### I can't find my notes after consolidation
 
@@ -416,10 +417,11 @@ No theoretical limit. Each note = 1 S3 file (~200-500 bytes). Consolidation proc
 | ----------------------------- | --------------- |
 | `live_note` (write)           | ~50ms           |
 | `live_read` (read)            | ~100ms          |
-| `bank_consolidate` (12 notes) | ~15-30s         |
+| `bank_consolidate` enqueue    | ~50ms           |
+| Background consolidation (12 notes) | ~15-30s   |
 | `bank_read_all` (6 files)     | ~200ms          |
 | `system_health`               | ~500ms          |
 
 ### How many simultaneous agents?
 
-No limit on the number of agents writing in parallel (append-only, zero conflicts). Consolidation is queued FIFO per space (1 job mutates a space's bank at a time).
+No limit on the number of agents writing in parallel (append-only, zero conflicts). Consolidation is queued FIFO per space (1 job mutates a space's bank at a time). `bank_consolidate` is a call-once async handoff; do not watch/poll unless explicitly requested.

--- a/README.fr.md
+++ b/README.fr.md
@@ -9,6 +9,8 @@
 [![MCP](https://img.shields.io/badge/protocol-MCP-purple.svg)]()
 [![Python](https://img.shields.io/badge/python-3.11+-yellow.svg)]()
 
+🇬🇧 [English version](README.md)
+
 ---
 
 ## 📋 Table des matières
@@ -18,67 +20,66 @@
 - [Prérequis](#-prérequis)
 - [Installation](#-installation)
 - [Configuration](#-configuration)
-- [Démarrage](#-démarrage)
+- [Démarrage rapide](#-démarrage-rapide)
 - [Outils MCP](#-outils-mcp)
 - [Graph Bridge](#-graph-bridge--pont-vers-graph-memory)
-- [README English](#-readme-english)
-- [Interface Web](#-interface-web)
+- [Interface web](#-interface-web)
 - [Intégration MCP](#-intégration-mcp)
-- [CLI et Shell](#-cli-et-shell)
+- [CLI et shell](#-cli-et-shell)
 - [Tests](#-tests)
 - [Sécurité](#-sécurité)
 - [Structure du projet](#-structure-du-projet)
-- [Dépannage](#-dépannage)
+- [Troubleshooting](#-troubleshooting)
 
 ---
 
 ## 🎯 Concept
 
-**Live Memory** est un serveur MCP (Model Context Protocol) qui fournit une **Memory Bank as a Service** pour agents IA. Plusieurs agents collaborent sur un même projet en partageant une mémoire de travail commune.
+**Live Memory** est un serveur MCP (Model Context Protocol) qui fournit une **Memory Bank as a Service** pour les agents IA. Plusieurs agents collaborent sur le même projet en partageant une mémoire de travail commune.
 
 ```
-graph-memory  = Mémoire LONG TERME (documents → Knowledge Graph → RAG vectoriel)
-live-memory   = Mémoire de TRAVAIL (notes live → LLM → Memory Bank structurée)
+graph-memory  = mémoire LONG TERME (documents → Knowledge Graph → RAG vectoriel)
+live-memory   = mémoire DE TRAVAIL (notes live → LLM → Memory Bank structurée)
 ```
 
 ### Deux modes complémentaires
 
-| Mode         | Description                                                       | Analogie                   |
-| ------------ | ----------------------------------------------------------------- | -------------------------- |
-| **🔴 Live** | Notes temps réel (observations, décisions, todos...) append-only  | Tableau blanc partagé      |
-| **📘 Bank** | Consolidation LLM en fichiers Markdown structurés selon des rules | Cahier de projet structuré |
+| Mode         | Description                                                              | Analogie                |
+| ------------ | ------------------------------------------------------------------------ | ----------------------- |
+| **🔴 Live** | Notes temps réel (observations, décisions, todos...) append-only         | Tableau blanc partagé   |
+| **📘 Bank** | Consolidation LLM en fichiers Markdown structurés selon les rules        | Journal projet structuré |
 
 ### Pourquoi Live Memory ?
 
-| Problème                                    | Solution Live Memory                                            |
-| ------------------------------------------- | --------------------------------------------------------------- |
-| Agents perdent leur contexte entre sessions | `bank_read_all` → contexte complet en 1 appel                   |
-| Collaboration multi-agents impossible       | Notes append-only, pas de conflit, visibilité croisée           |
-| Consolidation manuelle fastidieuse          | LLM transforme les notes brutes en documentation structurée     |
-| Mémoire dispersée en fichiers locaux        | Point central S3, accessible de partout                         |
-| Pas de lien avec la mémoire long terme      | 🌉 Graph Bridge pousse la bank dans un graphe de connaissances |
+| Problème                                  | Solution Live Memory                                       |
+| ----------------------------------------- | ---------------------------------------------------------- |
+| Les agents perdent le contexte entre sessions | `bank_read_all` → contexte complet en 1 appel          |
+| La collaboration multi-agent est impossible | Notes append-only, zéro conflit, visibilité croisée      |
+| La consolidation manuelle est fastidieuse | Le LLM transforme les notes brutes en doc structurée      |
+| Mémoire éparpillée dans des fichiers locaux | Point central S3, accessible de partout                  |
+| Pas de lien avec la mémoire long terme    | 🌉 Le Graph Bridge pousse la bank dans un knowledge graph |
 
-### 🧠 Collaboration multi-agents et architecture mémoire à deux niveaux
+### 🧠 Collaboration multi-agent et architecture mémoire à deux niveaux
 
-La recherche récente sur les systèmes multi-agents à base de LLM ([Tran et al., 2025 — *Multi-Agent Collaboration Mechanisms: A Survey of LLMs*](https://arxiv.org/abs/2501.06322)) identifie la **mémoire partagée** comme un composant fondamental. Dans leur cadre formel, un système multi-agents est défini par des **agents** (A), un **environnement partagé** (E) et des **canaux de collaboration** (C). Les auteurs soulignent que les LLM sont intrinsèquement des algorithmes isolés, non conçus pour collaborer — ils ont besoin d'une **infrastructure de mémoire partagée** pour coordonner leurs actions.
+Les recherches récentes sur les systèmes multi-agent basés LLM ([Tran et al., 2025 — *Multi-Agent Collaboration Mechanisms: A Survey of LLMs*](https://arxiv.org/abs/2501.06322)) identifient la **mémoire partagée** comme un composant fondamental. Dans leur cadre formel, un système multi-agent est défini par des **agents** (A), un **environnement partagé** (E) et des **canaux de collaboration** (C). Les auteurs soulignent que les LLM sont intrinsèquement des algorithmes isolés, non conçus pour collaborer — ils ont besoin d'une **infrastructure de mémoire partagée** pour coordonner leurs actions.
 
-Live Memory + Graph Memory implémente directement cette architecture :
+Live Memory + Graph Memory met directement en œuvre cette architecture :
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                  Environnement partagé E                    │
 │                                                             │
-│  ┌──────────────────┐   LLM    ┌─────────────────────┐      │
-│  │   Live           │ ──────►  │   Bank              │      │
-│  │  Notes temps réel│ consolide│  Mémoire de travail │      │
-│  │  (append-only)   │          │  structurée         │      │
-│  └──────────────────┘          └──────────┬──────────┘      │
+│  ┌──────────────────┐   LLM   ┌──────────────────────┐      │
+│  │   Live           │ ──────► │   Bank               │      │
+│  │  Notes temps réel│ consoli-│  Mémoire de travail  │      │
+│  │  (append-only)   │   de    │  structurée          │      │
+│  └──────────────────┘         └──────────┬───────────┘      │
 │                                          │                  │
 │                                     graph_push              │
 │                                     (MCP Streamable HTTP)   │
 │                                          │                  │
 │                               ┌──────────▼───────────┐      │
-│                               │     Graph Memory     │      │
+│                               │  🌐 Graph Memory     │      │
 │                               │  Knowledge Graph     │      │
 │                               │  (entités, relations,│      │
 │                               │   embeddings, RAG)   │      │
@@ -86,23 +87,23 @@ Live Memory + Graph Memory implémente directement cette architecture :
 └─────────────────────────────────────────────────────────────┘
 ```
 
-| Niveau                 | Service      | Durée            | Contenu                                     | Usage                                                  |
-| ---------------------- | ------------ | ---------------- | ------------------------------------------- | ------------------------------------------------------ |
-| **Mémoire de travail** | Live Memory  | Session / projet | Notes brutes + bank consolidée Markdown     | Contexte opérationnel, coordination quotidienne        |
-| **Mémoire long terme** | Graph Memory | Permanent        | Entités + relations + embeddings vectoriels | Base de connaissances interrogeable en langage naturel |
+| Niveau                | Service      | Durée               | Contenu                                  | Usage                                              |
+| --------------------- | ------------ | ------------------- | ---------------------------------------- | -------------------------------------------------- |
+| **Mémoire de travail** | Live Memory  | Session / projet    | Notes brutes + bank Markdown consolidée  | Contexte opérationnel, coordination quotidienne    |
+| **Mémoire long terme** | Graph Memory | Permanent           | Entités + relations + embeddings vectoriels | Base de connaissances interrogeable en langue naturelle |
 
-**Le Graph Bridge** (`graph_push`) est le canal de collaboration entre ces deux niveaux. Conformément au pattern **late-stage collaboration** décrit dans la littérature (partage des outputs consolidés comme inputs d'un autre système), il transforme la documentation de travail (Markdown) en connaissances structurées (graphe d'entités/relations).
+**Le Graph Bridge** (`graph_push`) est le canal de collaboration entre ces deux niveaux. Suivant le pattern de **late-stage collaboration** décrit dans la littérature (partage des sorties consolidées comme entrées d'un autre système), il transforme la documentation de travail (Markdown) en connaissance structurée (graphe d'entités/relations).
 
 **Pourquoi deux niveaux ?** Un seul niveau ne suffit pas :
-- La mémoire de travail seule est **éphémère** — elle disparaît quand le projet se termine
-- Le graphe de connaissances seul est **trop lourd** pour des notes quotidiennes rapides
-- Le pont entre les deux permet aux agents de **travailler vite** (notes live) tout en **capitalisant** les connaissances (graphe)
+- La mémoire de travail seule est **éphémère** — elle disparaît à la fin du projet
+- Le knowledge graph seul est **trop lourd** pour des notes quotidiennes rapides
+- Le pont entre les deux permet aux agents de **travailler vite** (notes live) tout en **capitalisant** la connaissance (graphe)
 
 Concrètement, les agents peuvent :
-1. **Écrire rapidement** des notes sans friction (live-memory, append-only, ~50ms)
+1. **Écrire vite** sans friction (live-memory, append-only, ~50ms)
 2. **Consolider automatiquement** via LLM en documentation structurée (bank, ~15s)
-3. **Pérenniser les connaissances** dans un graphe interrogeable (graph-memory, ~2min)
-4. **Interroger le graphe** en langage naturel pour retrouver des informations de projets passés
+3. **Persister la connaissance** dans un graphe interrogeable (graph-memory, ~2 min)
+4. **Interroger le graphe** en langage naturel pour retrouver l'information des projets passés
 
 ---
 
@@ -113,7 +114,7 @@ Concrètement, les agents peuvent :
           │                   │                │
           └────────┬──────────┘                │
                    │                           │
-                   ▼  MCP Protocol (Streamable HTTP)  ▼
+                   ▼  Protocole MCP (Streamable HTTP)  ▼
           ┌────────────────────────────────────────┐
           │   Caddy WAF (Coraza CRS)               │
           │   Rate Limiting • TLS • OWASP CRS      │
@@ -121,7 +122,7 @@ Concrètement, les agents peuvent :
                        │
           ┌────────────┴───────────────────┐
           │   Live Memory MCP (:8002)      │
-          │   40 outils • Auth Bearer      │
+          │   42 outils • Auth Bearer      │
           │   Consolidation LLM            │
           └──────┬──────────┬──────┬───────┘
                  │          │      │
@@ -136,8 +137,8 @@ Concrètement, les agents peuvent :
                        └────────────────────────┘
 ```
 
-**Stack minimale** : S3 + LLM. Pas de base de données locale.
-**Optionnel** : connexion à Graph Memory pour la mémoire long terme (graphe de connaissances).
+**Stack minimale** : S3 + LLM. Aucune base de données locale.
+**Optionnel** : connexion à Graph Memory pour la mémoire long terme (knowledge graph).
 
 ---
 
@@ -146,7 +147,7 @@ Concrètement, les agents peuvent :
 - **Docker** >= 24.0 + **Docker Compose** v2
 - **Python 3.11+** (pour la CLI, optionnel)
 - Un **stockage S3** compatible (Cloud Temple Dell ECS, AWS, MinIO)
-- Un **LLM** compatible OpenAI API (Cloud Temple LLMaaS, OpenAI, etc.)
+- Un **LLM** compatible API OpenAI (Cloud Temple LLMaaS, OpenAI, etc.)
 
 ---
 
@@ -165,37 +166,9 @@ cd live-memory
 cp .env.example .env
 ```
 
-Éditez `.env` avec vos valeurs (voir section [Configuration](#-configuration)).
+Éditez `.env` avec vos valeurs (voir [Configuration](#-configuration)).
 
-### 3a. Démarrage avec l'image pré-construite (recommandé)
-
-Des images Docker multi-arch (amd64 / arm64) sont publiées automatiquement par la CI sur GHCR.
-
-| Tag | Description |
-|-----|-------------|
-| `latest` | Dernière version stable |
-| `1.7.0` | Version fixée |
-| `main` | Dernier commit sur `main` |
-
-**Avec WAF (déploiement normal — port 8080) :**
-
-```bash
-# Éditez .env avec vos valeurs, puis :
-IMAGE_TAG=latest docker compose up -d
-curl -s http://localhost:8080/health
-```
-
-**Sans WAF (dev / test — port 8002 direct) :**
-
-```bash
-# Éditez .env avec vos valeurs, puis :
-IMAGE_TAG=latest docker compose -f docker-compose.nowaf.yml up -d
-curl -s http://localhost:8002/health
-```
-
-> **Note** : pour utiliser l'image distante, remplacez `build: .` par `image: ghcr.io/cloud-temple/live-memory:${IMAGE_TAG:-latest}` dans votre fichier compose.
-
-### 3b. Démarrage Docker avec build local
+### 3a. Démarrage Docker (recommandé)
 
 ```bash
 # Construire les images (WAF + serveur MCP)
@@ -204,14 +177,14 @@ docker compose build
 # Démarrer les services
 docker compose up -d
 
-# Vérifier que tout tourne
+# Vérifier le statut
 docker compose ps
 
-# Vérifier la santé
+# Health check
 curl -s http://localhost:8080/health
 ```
 
-### 3c. Démarrage local (développement)
+### 3b. Démarrage local (développement)
 
 ```bash
 # Installer les dépendances
@@ -233,17 +206,16 @@ uv pip install -e .
 # Health check via la CLI
 python scripts/mcp_cli.py health
 
-# Ou test E2E complet (crée un espace, écrit des notes, consolide)
+# Ou test E2E complet (crée un space, écrit des notes, consolide)
 python scripts/test_recette.py
 ```
 
 ### Ports exposés
 
-| Service                 | Port   | Description                                                              |
-| ----------------------- | ------ | ------------------------------------------------------------------------ |
-| **WAF**                 | `8080` | Seul port exposé (mode normal) — Caddy WAF → Live Memory                 |
-| **MCP Server (no WAF)** | `8002` | Accessible directement via `docker-compose.nowaf.yml` (dev / test)       |
-| MCP Server              | `8002` | Réseau Docker interne uniquement (mode normal)                           |
+| Service    | Port   | Description                                       |
+| ---------- | ------ | ------------------------------------------------- |
+| **WAF**    | `8080` | Seul port exposé — Caddy WAF → Live Memory        |
+| Serveur MCP | `8002` | Réseau Docker interne uniquement                |
 
 ---
 
@@ -253,44 +225,44 @@ python scripts/test_recette.py
 
 ### Variables obligatoires
 
-| Variable               | Description              | Exemple                                      |
-| ---------------------- | ------------------------ | -------------------------------------------- |
-| `S3_ENDPOINT_URL`      | URL endpoint S3          | `https://takinc5acc.s3.fr1.cloud-temple.com` |
-| `S3_ACCESS_KEY_ID`     | Access key S3            | `AKIA...`                                    |
-| `S3_SECRET_ACCESS_KEY` | Secret key S3            | `wJal...`                                    |
-| `S3_BUCKET_NAME`       | Nom du bucket            | `live-mem`                                   |
-| `S3_REGION_NAME`       | Région S3                | `fr1`                                        |
-| `LLMAAS_API_URL`       | URL API LLM (doit inclure `/v1`)  | `https://api.ai.cloud-temple.com/v1` |
-| `LLMAAS_API_KEY`       | Clé API LLM                       | `sk-...`                             |
-| `ADMIN_BOOTSTRAP_KEY`  | Clé admin bootstrap (≥ 32 chars)  | `ma-cle-secrete-changez-moi`        |
+| Variable               | Description                       | Exemple                                     |
+| ---------------------- | --------------------------------- | ------------------------------------------- |
+| `S3_ENDPOINT_URL`      | URL du endpoint S3                | `https://takinc5acc.s3.fr1.cloud-temple.com` |
+| `S3_ACCESS_KEY_ID`     | Clé d'accès S3                    | `AKIA...`                                   |
+| `S3_SECRET_ACCESS_KEY` | Clé secrète S3                    | `wJal...`                                   |
+| `S3_BUCKET_NAME`       | Nom du bucket                     | `live-mem`                                  |
+| `S3_REGION_NAME`       | Région S3                         | `fr1`                                       |
+| `LLMAAS_API_URL`       | URL de l'API LLM (avec `/v1`)     | `https://api.ai.cloud-temple.com/v1`        |
+| `LLMAAS_API_KEY`       | Clé d'API LLM                     | `sk-...`                                    |
+| `ADMIN_BOOTSTRAP_KEY`  | Clé bootstrap admin (≥ 32 chars)  | `ma-cle-secrete-a-changer`                  |
 
 ### Variables optionnelles — LLM
 
 Le consolidateur utilise un LLM (API compatible OpenAI) pour transformer les notes live en fichiers bank structurés.
 
-| Variable                  | Défaut            | Description                      |
-| ------------------------- | ----------------- | -------------------------------- |
-| `LLMAAS_MODEL`            | `qwen3.5:27b` | Nom du modèle LLM tel qu'exposé par le provider |
-| `LLMAAS_CONTEXT_WINDOW`   | `131072`          | Fenêtre de contexte TOTALE du modèle (entrée + sortie combinés, en tokens). Qwen3 235B = 128K |
+| Variable                  | Défaut            | Description                     |
+| ------------------------- | ----------------- | ------------------------------- |
+| `LLMAAS_MODEL`            | `qwen3.5:27b`     | Nom du modèle LLM tel qu'exposé par le fournisseur |
+| `LLMAAS_CONTEXT_WINDOW`   | `131072`          | Context window TOTAL du modèle (input + output combinés, en tokens). Qwen3 235B = 128K |
 | `LLMAAS_MAX_TOKENS`       | `16384`           | Budget de SORTIE max par requête (en tokens). Le consolidateur l'ajuste dynamiquement : `output = min(MAX_TOKENS, CONTEXT_WINDOW - input)` |
 | `LLMAAS_TEMPERATURE`      | `0.3`             | Créativité du LLM (0.0 = déterministe, 1.0 = très créatif) |
+| `PROXY_URL`               | _(aucun)_         | Proxy HTTP sortant (ex. `http://10.0.0.1:3128`). **Variable maison** (pas `HTTP_PROXY`) — injectée manuellement dans boto3 (S3) et httpx (LLM). Non supportée pour les connexions Graph Memory. |
 
 ### Variables optionnelles — Consolidation et compaction
 
-| Variable                  | Défaut            | Description                      |
-| ------------------------- | ----------------- | -------------------------------- |
-| `MCP_SERVER_PORT`         | `8002`            | Port d'écoute du serveur MCP     |
+| Variable                  | Défaut            | Description                     |
+| ------------------------- | ----------------- | ------------------------------- |
+| `MCP_SERVER_PORT`         | `8002`            | Port d'écoute du serveur MCP    |
 | `MCP_SERVER_DEBUG`        | `false`           | Logs détaillés (messages d'erreur complets) |
 | `CONSOLIDATION_TIMEOUT`   | `600`             | Timeout par appel LLM (secondes) |
-| `CONSOLIDATION_MAX_NOTES` | `500`             | Max notes traitées par consolidation |
-| `CONSOLIDATION_BATCH_SIZE`| `5`               | Notes par lot LLM (petit = précis, grand = rapide) |
-| `COMPACT_THRESHOLD`       | `0.6`             | Seuil auto-compaction (0.6 = compacte si bank > 60% du budget) |
-| `BANK_FILE_MAX_SIZE`      | `15360`           | Taille max par fichier bank (bytes, 15 KB). Au-delà = compaction |
-| `PROXY_URL`               | _(aucun)_         | Proxy HTTP sortant (ex: `http://10.0.0.1:3128`). Variable **custom** (pas `HTTP_PROXY`) — injecté manuellement dans boto3 (S3) et httpx (LLM). Non supporté pour Graph Memory. |
+| `CONSOLIDATION_MAX_NOTES` | `500`             | Max de notes par consolidation  |
+| `CONSOLIDATION_BATCH_SIZE`| `5`               | Notes par batch LLM (petit = précis, grand = plus rapide) |
+| `COMPACT_THRESHOLD`       | `0.6`             | Déclenchement de l'auto-compaction (0.6 = compacter si bank > 60% du budget) |
+| `BANK_FILE_MAX_SIZE`      | `15360`           | Taille max par fichier bank (octets, 15 KB). Au-dessus = candidat à la compaction |
 
 ---
 
-## ▶️ Démarrage
+## ▶️ Démarrage rapide
 
 ```bash
 docker compose up -d
@@ -302,57 +274,60 @@ docker compose logs -f live-mem-service --tail 50  # Logs
 
 ## 🔧 Outils MCP
 
-40 outils exposés via le protocole MCP (Streamable HTTP), répartis en 7 catégories.
+42 outils exposés via le protocole MCP (Streamable HTTP), répartis en 7 catégories.
 
 ### System (3 outils)
 
-| Outil           | Paramètres | Description                                               |
-| --------------- | ---------- | --------------------------------------------------------- |
-| `system_health` | —          | État de santé (S3, LLMaaS, nombre d'espaces)              |
-| `system_whoami` | —          | 👤 Identité du token courant (nom, permissions, espaces) |
-| `system_about`  | —          | Identité du service (version, outils, capacités)          |
+| Outil           | Paramètres | Description                                              |
+| --------------- | ---------- | -------------------------------------------------------- |
+| `system_health` | —          | Statut de santé (S3, LLMaaS, nombre de spaces)           |
+| `system_whoami` | —          | 👤 Identité du token courant (nom, permissions, spaces) |
+| `system_about`  | —          | Identité du service (version, outils, capacités)         |
 
 ### Space (9 outils)
 
-| Outil                | Paramètres                                   | Description                                                |
-| -------------------- | -------------------------------------------- | ---------------------------------------------------------- |
-| `space_create`       | `space_id`, `description`, `rules`, `owner?` | Crée un espace avec ses rules (structure de la bank)       |
-| `space_update`       | `space_id`, `description?`, `owner?`         | Met à jour la description et/ou le owner                   |
-| `space_update_rules` | `space_id`, `rules`                          | 📜 Met à jour les rules d'un espace (admin only)          |
-| `space_list`         | —                                            | Liste les espaces accessibles par le token courant         |
-| `space_info`    | `space_id`                                   | Infos détaillées (notes, bank, consolidation)              |
-| `space_rules`   | `space_id`                                   | Lit les rules immuables de l'espace                        |
-| `space_summary` | `space_id`                                   | Synthèse complète : rules + bank + stats (démarrage agent) |
-| `space_export`  | `space_id`                                   | Export tar.gz en base64                                    |
-| `space_delete`  | `space_id`, `confirm`                        | Supprime l'espace (⚠️ irréversible, admin requis)        |
+| Outil                | Paramètres                                   | Description                                                  |
+| -------------------- | -------------------------------------------- | ------------------------------------------------------------ |
+| `space_create`       | `space_id`, `description`, `rules`, `owner?` | Crée un space avec ses rules (structure de la bank)          |
+| `space_update`       | `space_id`, `description?`, `owner?`         | Met à jour la description et/ou l'owner                      |
+| `space_update_rules` | `space_id`, `rules`                          | 📜 Met à jour les rules du space (admin uniquement)         |
+| `space_list`         | —                                            | Liste les spaces accessibles par le token courant            |
+| `space_info`         | `space_id`                                   | Infos détaillées (notes, bank, consolidation)                |
+| `space_rules`        | `space_id`                                   | Lit les rules immuables du space                             |
+| `space_summary`      | `space_id`                                   | Résumé complet : rules + bank + stats (démarrage agent)      |
+| `space_export`       | `space_id`                                   | Export tar.gz en base64                                      |
+| `space_delete`       | `space_id`, `confirm`                        | Supprime le space (⚠️ irréversible, admin requis)           |
 
 ### Live (3 outils)
 
-| Outil         | Paramètres                                  | Description                                                                                                                 |
-| ------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `live_note`   | `space_id`, `category`, `content`, `tags?`  | Écrit une note horodatée (agent = token name). Catégories : observation, decision, todo, insight, question, progress, issue |
-| `live_read`   | `space_id`, `limit?`, `category?`, `agent?` | Lit les notes live (filtres optionnels)                                                                                     |
-| `live_search` | `space_id`, `query`, `limit?`               | Recherche plein texte dans les notes                                                                                        |
+| Outil         | Paramètres                                  | Description                                                                                                                |
+| ------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `live_note`   | `space_id`, `category`, `content`, `tags?`  | Écrit une note horodatée (agent = nom du token). Catégories : observation, decision, todo, insight, question, progress, issue |
+| `live_read`   | `space_id`, `limit?`, `category?`, `agent?` | Lit les notes live (filtres optionnels)                                                                                    |
+| `live_search` | `space_id`, `query`, `limit?`               | Recherche full-text dans les notes                                                                                         |
 
-### Bank (7 outils)
+### Bank (10 outils)
 
-| Outil              | Paramètres                            | Description                                                                                                |
-| ------------------ | ------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `bank_read`        | `space_id`, `filename`                | Lit un fichier bank (supporte les sous-dossiers : `personaProfiles/acheteur.md`)                           |
-| `bank_read_all`    | `space_id`                            | Lit toute la bank en une requête (🚀 démarrage agent)                                                     |
-| `bank_list`        | `space_id`                            | Liste les fichiers bank avec chemins relatifs (sans contenu)                                               |
-| `bank_consolidate` | `space_id`, `agent?`                  | 🧠 Consolide les notes via LLM. `agent` vide = toutes les notes (admin). `agent=nom` = notes de cet agent |
-| `bank_repair`      | `space_id`, `dry_run?`                | 🔧 Répare les noms corrompus (Unicode, préfixes parasites). `dry_run=True` par défaut (admin)              |
-| `bank_write`       | `space_id`, `filename`, `content`     | ✏️ Écrit/remplace un fichier bank directement — contourne la consolidation LLM (admin)                    |
-| `bank_delete`      | `space_id`, `filename`                | 🗑️ Supprime un fichier bank + ses doublons Unicode (admin, irréversible)                                  |
+| Outil                       | Paramètres                        | Description                                                                                                       |
+| --------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `bank_read`                 | `space_id`, `filename`            | Lit un fichier bank (supporte les sous-dossiers : `personaProfiles/acheteur.md`)                                  |
+| `bank_read_all`             | `space_id`                        | Lit toute la bank en une requête (🚀 démarrage agent)                                                            |
+| `bank_list`                 | `space_id`                        | Liste les fichiers bank avec chemins relatifs (sans contenu)                                                      |
+| `bank_consolidate`          | `space_id`, `agent?`              | 🧠 Enfile une consolidation LLM async. Appeler une seule fois ; ne pas surveiller/poller sauf demande explicite   |
+| `bank_consolidation_status` | `job_id`                          | Check de statut manuel uniquement pour un job retourné par `bank_consolidate`                                     |
+| `bank_consolidation_queues` | `space_ids?`                      | Résumé read-only des files de consolidation par space                                                             |
+| `bank_compact`              | `space_id`, `dry_run?`            | 🔧 Compacte les fichiers bank surdimensionnés via LLM. `dry_run=True` par défaut (admin)                          |
+| `bank_repair`               | `space_id`, `dry_run?`            | 🔧 Répare les noms de fichiers corrompus (Unicode, préfixes parasites). `dry_run=True` par défaut (admin)         |
+| `bank_write`                | `space_id`, `filename`, `content` | ✏️ Écrit/remplace un fichier bank directement — contourne la consolidation LLM (admin)                           |
+| `bank_delete`               | `space_id`, `filename`            | 🗑️ Supprime un fichier bank + ses doublons Unicode (admin, irréversible)                                         |
 
 ### Graph (4 outils) — 🌉 Pont vers Graph Memory
 
 | Outil              | Paramètres                                           | Description                                                                                                  |
 | ------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `graph_connect`    | `space_id`, `url`, `token`, `memory_id`, `ontology?` | Connecte un space à Graph Memory. Teste la connexion, crée la mémoire si besoin. Ontologie défaut: `general` |
-| `graph_push`       | `space_id`                                           | Synchronise la bank → graphe. Delete + re-ingest intelligent, nettoyage orphelins. ~30s/fichier              |
-| `graph_status`     | `space_id`                                           | Statut connexion + stats graphe (documents, entités, relations, top entités, liste documents)                |
+| `graph_connect`    | `space_id`, `url`, `token`, `memory_id`, `ontology?` | Connecte un space à Graph Memory. Teste la connexion, crée la mémoire si besoin. Ontologie par défaut : `general` |
+| `graph_push`       | `space_id`                                           | Synchronise bank → graphe. Delete + re-ingest intelligent, nettoyage orphelins. ~30s/fichier                 |
+| `graph_status`     | `space_id`                                           | Statut de connexion + stats du graphe (documents, entités, relations, top entités, liste de documents)       |
 | `graph_disconnect` | `space_id`                                           | Déconnecte (les données restent dans le graphe)                                                              |
 
 ### Backup (5 outils)
@@ -369,29 +344,58 @@ docker compose logs -f live-mem-service --tail 50  # Logs
 
 | Outil                | Paramètres                                                        | Description                                                                                                    |
 | -------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `admin_create_token` | `name`, `permissions`, `space_ids?`, `expires_in_days?`, `email?` | Crée un token (⚠️ affiché une seule fois). Permissions: read, write, admin. Email optionnel pour traçabilité |
+| `admin_create_token` | `name`, `permissions`, `space_ids?`, `expires_in_days?`, `email?` | Crée un token (⚠️ affiché une seule fois). Permissions : read, write, admin. Email optionnel pour traçabilité |
 | `admin_list_tokens`  | —                                                                 | Liste les tokens actifs                                                                                        |
 | `admin_revoke_token` | `token_hash`                                                      | Révoque un token (le rend inutilisable)                                                                        |
-| `admin_delete_token` | `token_hash`                                                      | Supprime physiquement un token du registre (⚠️ irréversible)                                                 |
+| `admin_delete_token` | `token_hash`                                                      | Supprime physiquement un token du registre (⚠️ irréversible)                                                  |
 | `admin_purge_tokens` | `revoked_only?`                                                   | Purge en masse : révoqués seuls (défaut) ou tous les tokens                                                    |
-| `admin_update_token` | `token_hash`, `space_ids`, `action`                               | Modifie les espaces d'un token (add/remove/set)                                                                |
+| `admin_update_token` | `token_hash`, `space_ids`, `action`                               | Modifie les spaces d'un token (add/remove/set)                                                                 |
 | `admin_gc_notes`     | `space_id?`, `max_age_days?`, `confirm?`, `delete_only?`          | Garbage Collector : nettoie les notes orphelines                                                               |
 
 ---
 
 ## 🌉 Graph Bridge — Pont vers Graph Memory
 
-Live Memory peut pousser sa Memory Bank dans une instance [Graph Memory](https://github.com/Cloud-Temple/graph-memory) pour la mémoire long terme. Le graphe de connaissances extrait les entités, relations et embeddings des fichiers bank.
+Live Memory peut pousser sa Memory Bank dans une instance [Graph Memory](https://github.com/Cloud-Temple/graph-memory) pour la mémoire long terme. Le knowledge graph extrait les entités, relations et embeddings des fichiers bank.
+
+### Workflow
+
+```
+1. graph_connect(space_id, url, token, memory_id, ontology="general")
+   └─ Teste la connexion, crée le Graph Memory si besoin
+
+2. bank_consolidate(space_id)
+   └─ Enfile une consolidation async ; appelez une seule fois et ne surveillez/pollez pas sauf demande explicite
+
+3. graph_push(space_id)
+   ├─ Liste les documents dans Graph Memory
+   ├─ Pour chaque fichier bank modifié :
+   │   ├─ document_delete (supprime les entités orphelines)
+   │   └─ memory_ingest (recalcul complet du graphe)
+   ├─ Nettoie les documents bank supprimés
+   └─ Met à jour les métriques (last_push, push_count)
+
+4. graph_status(space_id)
+   └─ Stats : 79 entités, 61 relations, top entités, documents...
+```
+
+### Push intelligent (delete + re-ingest)
+
+Chaque push est un **refresh complet** du graphe pour ce fichier. Les fichiers existants sont supprimés puis ré-ingérés pour que Graph Memory recalcule les entités, relations et embeddings avec le contenu à jour.
+
+### Ontologies disponibles
+
+| Ontologie           | Usage                                       |
+| ------------------- | ------------------------------------------- |
+| `general` (défaut)  | Polyvalente : FAQ, specs, certifications, RSE |
+| `legal`             | Documents juridiques, contrats              |
+| `cloud`             | Infrastructure cloud, fiches produit        |
+| `managed-services`  | Services managés, infogérance               |
+| `presales`          | Avant-vente, RFP/RFI, propositions          |
 
 ---
 
-## 🇬🇧 English README
-
-An English version of this documentation is available here: [README.md](README.md)
-
----
-
-## 🖥️ Interface Web
+## 🖥️ Interface web
 
 Live Memory expose une **interface web** sur `/live` pour visualiser les espaces mémoire en temps réel.
 
@@ -405,35 +409,35 @@ http://localhost:8080/live
 
 | Zone                                | Contenu                                                                                                                          |
 | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| **📊 Dashboard** (gauche)          | Infos espace, consolidation (date + compteurs), stats live/bank, agents colorés, catégories avec %, rules Markdown, Graph Memory |
-| **🔴 Live Timeline** (haut-droite) | Notes live groupées par date (Aujourd'hui/Hier/date), cards avec agent + catégorie + Markdown                                    |
-| **📘 Bank Viewer** (bas-droite)    | Onglets de fichiers consolidés, rendu Markdown avec marked.js                                                                    |
+| **📊 Dashboard** (gauche)          | Infos space, consolidation (date + compteurs), stats live/bank, agents colorés, catégories avec %, rules Markdown, Graph Memory |
+| **🔴 Live Timeline** (haut-droite) | Notes live groupées par date (Aujourd'hui/Hier/date), cartes avec agent + catégorie + Markdown                                  |
+| **📘 Bank Viewer** (bas-droite)    | Onglets de fichiers consolidés, rendu Markdown via marked.js                                                                    |
 
 ### Layout
 
 ```
 ┌──────────────┬────────────────────────────┐
 │  📊 Dashboard│  🔴 Live Timeline          │
-│  (infos,     │  (auto-refresh, groupé/date)│
+│  (infos,     │  (auto-refresh, groupé date)│
 │   agents,    ├────────────────────────────┤
-│   rules...)  │  📘 Bank (onglets Markdown) │
+│   rules...)  │  📘 Bank (onglets Markdown)│
 └──────────────┴────────────────────────────┘
 ```
 
 ### Auto-refresh intelligent
 
 - Configurable : 3s / 5s / 10s / 30s / manuel
-- **Anti-flicker** : ne re-rend le DOM que si les données ont changé
-- Pastille verte pulsante avec timestamp du dernier refresh
-- Sélection d'espace → chargement immédiat (pas de bouton)
+- **Anti-flicker** : ne re-render le DOM que si les données ont changé
+- Point vert pulsant avec timestamp du dernier refresh
+- Sélection d'un space → chargement immédiat (pas de bouton à cliquer)
 
 ### API REST (5 endpoints)
 
 | Endpoint                        | Description                                              |
 | ------------------------------- | -------------------------------------------------------- |
-| `GET /api/spaces`               | Liste des espaces                                        |
-| `GET /api/space/{id}`           | Info complète (meta + rules + stats + graph-memory)      |
-| `GET /api/live/{id}`            | Notes live (filtres: `?agent=`, `?category=`, `?limit=`) |
+| `GET /api/spaces`               | Liste des spaces                                         |
+| `GET /api/space/{id}`           | Infos complètes (meta + rules + stats + graph-memory)    |
+| `GET /api/live/{id}`            | Notes live (filtres : `?agent=`, `?category=`, `?limit=`) |
 | `GET /api/bank/{id}`            | Liste des fichiers bank                                  |
 | `GET /api/bank/{id}/{filename}` | Contenu d'un fichier bank                                |
 
@@ -441,7 +445,7 @@ Les endpoints `/api/*` nécessitent un Bearer Token. La page `/live` et les fich
 
 ### Console d'administration (`/admin`)
 
-Une **console d'administration** complète est disponible à `/admin`, exposant les 42 outils MCP via une interface web :
+Une **console d'administration** complète est disponible sur `/admin`, exposant les 42 outils MCP via une interface web :
 
 ```
 http://localhost:8080/admin
@@ -449,27 +453,27 @@ http://localhost:8080/admin
 
 | Section | Fonctionnalités |
 | --- | --- |
-| **📊 Dashboard** | Santé (clic → détail services), nombre de spaces, tokens actifs, version/uptime, barre d'identité |
+| **📊 Dashboard** | Statut de santé (cliquable → détails service), nombre de spaces, tokens actifs, version/uptime, barre d'identité |
 | **📂 Spaces** | CRUD, modales info/rules, lien explorer, suppression avec confirmation |
-| **🔑 Tokens** | Création/modification/révocation/suppression, chips visuels avec calcul delta |
-| **🔍 Explorer** | Notes live + fichiers bank côte-à-côte pour chaque espace |
-| **💾 Backups** | Création/restauration/suppression, "Backup All", colonnes dynamiques |
-| **🌉 Graph Bridge** | Vérification statut, push, déconnexion par espace |
-| **🧹 Maintenance** | Consolidation, compaction, réparation, GC, purge — sélecteur unique, liste compacte |
+| **🔑 Tokens** | Création/mise à jour/révocation/suppression, chips de spaces visuels avec calcul de delta |
+| **🔍 Explorer** | Notes live + fichiers bank côte à côte pour n'importe quel space |
+| **💾 Backups** | Création/restauration/suppression, « Backup All », colonnes dynamiques |
+| **🌉 Graph Bridge** | Check de statut, push, déconnexion par space |
+| **🧹 Maintenance** | Consolider, compacter, réparer, GC, purger — sélecteur de space unique, liste d'actions compacte |
 
-- **Auth** : nécessite un token valide (même auth que `/live`), session via cookie HttpOnly
-- **CSP-safe** : zéro handler inline, tout via `data-action` + event delegation
-- **Upload Rules** : sélecteur de fichier (`.md`) ou collage direct depuis la modale Rules
+- **Auth** : nécessite un token valide (comme `/live`), session via cookie HttpOnly
+- **Compatible CSP** : zéro handler inline, tout via `data-action` + délégation d'événements
+- **Upload Rules** : file picker (`.md`) ou paste direct depuis la modale Rules
 
 ---
 
 ## 🔌 Intégration MCP
 
-> 📖 **Guide complet** : Voir [GUIDE_INTEGRATION_CLINE.md](GUIDE_INTEGRATION_CLINE.md) pour le guide pas-à-pas détaillé (configuration Cline, custom instructions, workflow, multi-agents, dépannage).
+> 📖 **Guide complet** : voir [CLINE_INTEGRATION_GUIDE.fr.md](CLINE_INTEGRATION_GUIDE.fr.md) pour le guide pas à pas (configuration Cline, custom instructions, workflow, multi-agents, troubleshooting).
 
 ### Avec Cline (VS Code / VSCodium)
 
-Dans les settings MCP de Cline (`cline_mcp_settings.json`) - n'oubliez pas /mcp :
+Dans les paramètres MCP de Cline (`cline_mcp_settings.json`) :
 
 ```json
 {
@@ -477,22 +481,22 @@ Dans les settings MCP de Cline (`cline_mcp_settings.json`) - n'oubliez pas /mcp 
     "live-memory": {
       "url": "http://localhost:8080/mcp",
       "headers": {
-        "Authorization": "Bearer lm_VOTRE_TOKEN"
+        "Authorization": "Bearer lm_YOUR_TOKEN"
       }
     }
   }
 }
 ```
 
-Pour configurer les **Custom Instructions** de votre agent, copiez le fichier [`clinerules.md`](clinerules.md) dans vos Custom Instructions globales Cline (ou dans un `.clinerules/` de votre projet). Il suffit de modifier **deux valeurs** :
-- Le **nom du serveur MCP** (tel que configuré dans `cline_mcp_settings.json`, ex: `my-live-mem`)
-- Le **nom de votre espace mémoire** (l'identifiant passé à `space_create`, ex: `mon-projet`)
+Pour configurer les **Custom Instructions** de votre agent, copiez le fichier [`clinerules.md`](clinerules.md) dans vos Custom Instructions globales Cline (ou dans un dossier `.clinerules/` à la racine du projet). Vous n'avez qu'**à changer deux valeurs** :
+- Le **nom du serveur MCP** (tel que configuré dans `cline_mcp_settings.json`, ex. `my-live-mem`)
+- Le **nom de votre espace mémoire** (l'ID passé à `space_create`, ex. `mon-projet`)
 
-Le nom de l'agent est **auto-détecté** depuis le token d'authentification — rien d'autre à configurer.
+Le nom d'agent est **auto-détecté** depuis le token d'authentification — rien d'autre à configurer.
 
 > 💡 **Template prêt à l'emploi :** [`clinerules.md`](clinerules.md) — copier et personnaliser les 2 valeurs en gras
 >
-> 📖 **Guide détaillé :** [Guide d'intégration Cline & Custom Instructions](GUIDE_INTEGRATION_CLINE.md)
+> 📖 **Guide détaillé :** [Guide d'intégration & Custom Instructions Cline](CLINE_INTEGRATION_GUIDE.fr.md)
 
 ### Avec Claude Desktop
 
@@ -504,7 +508,7 @@ Dans `claude_desktop_config.json` :
     "live-memory": {
       "url": "http://localhost:8080/mcp",
       "headers": {
-        "Authorization": "Bearer lm_VOTRE_TOKEN"
+        "Authorization": "Bearer lm_YOUR_TOKEN"
       }
     }
   }
@@ -517,8 +521,8 @@ Dans `claude_desktop_config.json` :
 from mcp.client.streamable_http import streamablehttp_client
 from mcp import ClientSession
 
-async def exemple():
-    headers = {"Authorization": "Bearer votre_token"}
+async def example():
+    headers = {"Authorization": "Bearer your_token"}
     async with streamablehttp_client("http://localhost:8080/mcp", headers=headers) as (r, w, _):
         async with ClientSession(r, w) as session:
             await session.initialize()
@@ -532,15 +536,15 @@ async def exemple():
             await session.call_tool("live_note", {
                 "space_id": "mon-projet",
                 "category": "observation",
-                "content": "Le build passe en CI"
+                "content": "Build qui passe en CI"
             })
 ```
 
 ---
 
-## 💻 CLI et Shell
+## 💻 CLI et shell
 
-### Installation CLI
+### Installation de la CLI
 
 ```bash
 pip install click rich prompt-toolkit mcp[cli]>=1.8.0
@@ -578,7 +582,7 @@ Autocomplétion, historique, affichage Rich. Voir [scripts/README.md](scripts/RE
 
 ## 🧪 Tests
 
-Script de recette **unifié** avec 4 suites sélectionnables par `--suite` :
+Script de tests unifié avec **4 suites sélectionnables** via `--suite` :
 
 ```bash
 docker compose up -d   # Prérequis
@@ -586,12 +590,12 @@ docker compose up -d   # Prérequis
 # Toutes les suites (44 tests, ~60s)
 python scripts/test_recette.py --url http://localhost:8080
 
-# Juste une suite
+# Une seule suite
 python scripts/test_recette.py --suite recette     # Pipeline agent (7 tests)
 python scripts/test_recette.py --suite isolation    # Multi-tenant (18 tests)
 python scripts/test_recette.py --suite qualite      # Outils MCP (19 tests)
 
-# Suite Graph Memory (optionnelle, nécessite graph-memory en cours)
+# Suite Graph Memory (optionnelle, nécessite un graph-memory démarré)
 python scripts/test_recette.py --suite graph \
   --graph-url http://host.docker.internal:8080 \
   --graph-token votre_token
@@ -599,18 +603,16 @@ python scripts/test_recette.py --suite graph \
 # Lister les suites disponibles
 python scripts/test_recette.py --list
 
-# Mode pas-à-pas + verbose
+# Pas à pas + verbose
 python scripts/test_recette.py --suite isolation -v --step --no-cleanup
 ```
 
-| Suite       | Tests | Description                                                                             |
-| ----------- | ----- | --------------------------------------------------------------------------------------- |
-| `recette`   | 7     | Pipeline complet : token → notes → consolidation LLM → bank                             |
-| `isolation` | 18    | Isolation multi-tenant v0.7.1 : accès inter-espaces, filtrage backups, auto-ajout token |
-| `qualite`   | 19    | Tests des 32 outils MCP : system, admin, space, live, bank, backup, GC                  |
-| `graph`     | ~8    | Pont Graph Memory : connect, push, status, disconnect (optionnel)                       |
-
-Voir [scripts/README.md](scripts/README.md) pour le détail complet.
+| Suite       | Tests | Description                                                                              |
+| ----------- | ----- | ---------------------------------------------------------------------------------------- |
+| `recette`   | 7     | Pipeline complet : token → notes → consolidation LLM → bank                              |
+| `isolation` | 18    | Isolation multi-tenant v0.7.1 : accès cross-space, filtrage backup, ajout auto au token  |
+| `qualite`   | 19    | Test des 35 outils MCP : system, admin, space, live, bank, backup, GC                    |
+| `graph`     | ~8    | Pont Graph Memory : connect, push, status, disconnect (optionnel)                        |
 
 ---
 
@@ -619,24 +621,17 @@ Voir [scripts/README.md](scripts/README.md) pour le détail complet.
 ### Authentification
 
 - **Bearer Token** obligatoire sur toutes les requêtes MCP
-- **Bootstrap key** pour créer le premier token admin
+- **Clé bootstrap** pour créer le premier token admin
 - **Tokens SHA-256** stockés sur S3 (jamais en clair)
 - **3 niveaux** : read, write, admin
-- **Scope par espace** : un token peut être limité à certains espaces
+- **Portée par space** : un token peut être limité à des spaces précis
 
 ### WAF (Caddy + Coraza)
 
 - **OWASP CRS** : injection SQL/XSS, path traversal, SSRF
 - **Rate Limiting** : 200 MCP/min (Streamable HTTP)
 - **TLS automatique** : Let's Encrypt en production (`SITE_ADDRESS=domaine.com`)
-- **Container non-root** : utilisateur `mcp`
-
-### Bonnes pratiques
-
-1. **Changez `ADMIN_BOOTSTRAP_KEY`** en production
-2. Ne commitez jamais `.env`
-3. Créez des tokens avec les permissions minimales
-4. Activez HTTPS via `SITE_ADDRESS`
+- **Conteneur non-root** : utilisateur `mcp`
 
 ---
 
@@ -654,54 +649,42 @@ live-memory/
 │   │   ├── live.html          #   SPA (Dashboard + Live + Bank)
 │   │   ├── css/live.css       #   Styles (thème Cloud Temple)
 │   │   ├── js/                #   7 modules JS (config, api, app, dashboard, timeline, bank, sidebar)
-│   │   └── img/               #   Logo Cloud Temple SVG
+│   │   └── img/               #   Logo SVG Cloud Temple
 │   ├── core/                  # Services métier
 │   │   ├── storage.py         #   S3 dual SigV2/SigV4 (Dell ECS)
-│   │   ├── space.py           #   CRUD espaces mémoire
+│   │   ├── space.py           #   CRUD des espaces mémoire
 │   │   ├── live.py            #   Notes live (append-only)
 │   │   ├── consolidator.py    #   Pipeline LLM (4 étapes)
 │   │   ├── graph_bridge.py    #   🌉 Pont vers Graph Memory
-│   │   ├── tokens.py          #   Gestion tokens SHA-256
+│   │   ├── tokens.py          #   Gestion des tokens SHA-256
 │   │   ├── backup.py          #   Snapshots S3
 │   │   ├── gc.py              #   Garbage Collector
-│   │   ├── locks.py           #   Locks asyncio par espace
+│   │   ├── locks.py           #   Locks asyncio par space
 │   │   └── models.py          #   Modèles Pydantic
-│   └── tools/                 # Outils MCP (7 modules, 57 params documentés)
+│   └── tools/                 # Outils MCP (7 modules)
 │       ├── system.py          #   3 outils (health, whoami, about)
-│       ├── space.py           #   9 outils (CRUD espaces) — 15 params
-│       ├── live.py            #   3 outils (notes) — 13 params
-│       ├── bank.py            #   7 outils (bank + consolidation + admin) — 10 params
-│       ├── graph.py           #   4 outils (Graph Bridge) — 8 params
-│       ├── backup.py          #   5 outils (snapshots) — 8 params
-│       └── admin.py           #   7 outils (tokens + GC + purge) — 14 params
+│       ├── space.py           #   9 outils (CRUD spaces)
+│       ├── live.py            #   3 outils (notes)
+│       ├── bank.py            #   8 outils (bank + consolidation + compaction + admin)
+│       ├── graph.py           #   4 outils (Graph Bridge)
+│       ├── backup.py          #   5 outils (snapshots)
+│       └── admin.py           #   8 outils (tokens + GC + purge + bulk)
 ├── scripts/                   # CLI + Shell + Tests
-│   ├── mcp_cli.py             #   Point d'entrée CLI Click + Shell
-│   ├── test_recette.py        #   🧪 Script de recette unifié (4 suites, ~50 tests)
-│   └── cli/                   #   Package CLI (client, commands, display, shell)
-├── waf/                       # WAF Caddy + Coraza
-│   ├── Caddyfile              #   Config WAF + rate limiting
-│   └── Dockerfile             #   Image Caddy + Coraza
-├── RULES/                     # 📐 Modèles de rules pour créer des espaces (5 templates)
-│   ├── README.md              #   Guide d'utilisation + pourquoi les rules sont critiques
-│   ├── live-mem.standard.memory.bank.md  # Modèle standard (6 fichiers, dev/archi/projet)
-│   ├── book.memory.bank.md    #   Modèle écriture de livre (6 fichiers, suivi narratif)
-│   ├── medical.memory.bank.md #   Modèle suivi médical (7+2 fichiers, fiabilité absolue)
-│   └── presales.memory.bank.md#   Modèle avant-vente B2B (5+N fichiers, personas dynamiques)
+├── waf/                       # Caddy + Coraza WAF
 ├── clinerules.md              # 📋 Template Custom Instructions Cline (copier + personnaliser)
 ├── DESIGN/live-mem/           # 9 documents d'architecture
 ├── docker-compose.yml
-├── docker-compose.nowaf.yml   # Stack sans WAF (dev / test) — port 8002 direct
 ├── Dockerfile
-├── pyproject.toml             # Dépendances & config projet (uv)
-├── uv.lock                    # Lockfile uv
-├── VERSION                    # 1.9.0
+├── pyproject.toml             # Dépendances et config projet (uv)
+├── uv.lock                    # lockfile uv
+├── VERSION                    # 2.2.0
 ├── CHANGELOG.md
-└── FAQ.md                     # 20 questions/réponses
+└── FAQ.md
 ```
 
 ---
 
-## 🔍 Dépannage
+## 🔍 Troubleshooting
 
 ### Le service ne démarre pas
 
@@ -710,36 +693,25 @@ docker compose logs live-mem-service --tail 50
 docker compose logs waf --tail 20
 ```
 
-### Erreur 401 Unauthorized
+### 401 Unauthorized
 
 - Vérifiez votre token : `Authorization: Bearer VOTRE_TOKEN`
-- La bootstrap key n'est pas un token — créez d'abord un token via `admin_create_token`
+- La clé bootstrap n'est pas un token — créez d'abord un token via `admin_create_token`
 
-### Consolidation échoue
+### La consolidation échoue
 
 - Vérifiez les credentials LLMaaS dans `.env`
-- Le timeout par défaut est 600s — augmentez `CONSOLIDATION_TIMEOUT` si nécessaire
-- Un seul `bank_consolidate` à la fois par espace (lock asyncio)
-
-### Graph Bridge : connexion impossible
-
-- Vérifiez que Graph Memory est accessible : `curl https://votre-graph-memory/mcp`
-- Vérifiez le token Graph Memory (Bearer)
-- L'URL peut être avec ou sans `/mcp` (normalisée automatiquement)
-
-### Rebuild après modification du code
-
-```bash
-docker compose build live-mem-service && docker compose up -d live-mem-service
-```
+- Le timeout par défaut est de 600s — augmentez `CONSOLIDATION_TIMEOUT` si besoin
+- `bank_consolidate` retourne un accusé de job async (`running` ou `queued`) avec `next_action="return_to_user_without_polling"` ; appelez-le une seule fois et ne surveillez/pollez pas sauf demande explicite
+- `bank_consolidation_status(job_id)` reste disponible pour des checks de statut manuels uniquement
 
 ---
 
 ## 🔗 Projets liés
 
-| Projet           | Description                                | Lien                                                                         |
-| ---------------- | ------------------------------------------ | ---------------------------------------------------------------------------- |
-| **graph-memory** | Mémoire long terme (Knowledge Graph + RAG) | [github.com/Cloud-Temple/graph-memory](https://github.com/Cloud-Temple/graph-memory) |
+| Projet           | Description                                | Lien                                                                                  |
+| ---------------- | ------------------------------------------ | ------------------------------------------------------------------------------------- |
+| **graph-memory** | Mémoire long terme (Knowledge Graph + RAG) | [github.com/Cloud-Temple/graph-memory](https://github.com/Cloud-Temple/graph-memory)  |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -306,15 +306,16 @@ docker compose logs -f live-mem-service --tail 50  # Logs
 | `live_read`   | `space_id`, `limit?`, `category?`, `agent?` | Reads live notes (optional filters)                                                                                         |
 | `live_search` | `space_id`, `query`, `limit?`               | Full-text search in notes                                                                                                   |
 
-### Bank (9 tools)
+### Bank (10 tools)
 
 | Tool               | Parameters                        | Description                                                                                             |
 | ------------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `bank_read`        | `space_id`, `filename`            | Reads a bank file (supports subfolders: `personaProfiles/buyer.md`)                                     |
 | `bank_read_all`    | `space_id`                        | Reads entire bank in one request (🚀 agent startup)                                                    |
 | `bank_list`        | `space_id`                        | Lists bank files with relative paths (without content)                                                  |
-| `bank_consolidate` | `space_id`, `agent?`              | 🧠 Enqueues LLM consolidation. Empty `agent` = all notes (admin). `agent=name` = notes from this agent |
-| `bank_consolidation_status` | `job_id`              | Tracks an in-memory consolidation job returned by `bank_consolidate` |
+| `bank_consolidate` | `space_id`, `agent?`              | 🧠 Enqueues async LLM consolidation. Call once; do not watch/poll unless explicitly requested |
+| `bank_consolidation_status` | `job_id`              | Manual-only status check for a job returned by `bank_consolidate` |
+| `bank_consolidation_queues` | `space_ids?`          | Read-only summary of consolidation lanes by space |
 | `bank_compact`     | `space_id`, `dry_run?`            | 🔧 Compacts oversized bank files via LLM. `dry_run=True` by default (admin)                            |
 | `bank_repair`      | `space_id`, `dry_run?`            | 🔧 Repairs corrupted filenames (Unicode, parasitic prefixes). `dry_run=True` by default (admin)        |
 | `bank_write`       | `space_id`, `filename`, `content` | ✏️ Writes/replaces a bank file directly — bypasses LLM consolidation (admin)                          |
@@ -364,7 +365,7 @@ Live Memory can push its Memory Bank into a [Graph Memory](https://github.com/Cl
    └─ Tests connection, creates Graph Memory if needed
 
 2. bank_consolidate(space_id)
-   └─ LLM produces/updates bank files
+   └─ Queues async consolidation; call once and do not watch/poll unless explicitly requested
 
 3. graph_push(space_id)
    ├─ Lists documents in Graph Memory
@@ -701,7 +702,8 @@ docker compose logs waf --tail 20
 
 - Check LLMaaS credentials in `.env`
 - Default timeout is 600s — increase `CONSOLIDATION_TIMEOUT` if needed
-- `bank_consolidate` is queued FIFO per space; only one job mutates a space's bank at a time (asyncio lock)
+- `bank_consolidate` returns an async job acknowledgement (`running` or `queued`) with `next_action="return_to_user_without_polling"`; call it once and do not watch/poll unless explicitly requested
+- `bank_consolidation_status(job_id)` remains available for manual status checks only
 
 ---
 

--- a/src/live_mem/core/consolidation_queue.py
+++ b/src/live_mem/core/consolidation_queue.py
@@ -28,6 +28,16 @@ logger = logging.getLogger("live_mem.consolidation_queue")
 
 QUEUE_GUARANTEE = "in_memory_best_effort"
 TERMINAL_STATUSES = {"succeeded", "failed"}
+NO_AUTO_POLLING_NEXT_ACTION = "return_to_user_without_polling"
+NO_AUTO_POLLING_CONTRACT = {
+    "recommended": False,
+    "mode": "manual_only",
+    "status_tool": "bank_consolidation_status",
+    "instruction": (
+        "Do not wait for completion or poll automatically. Store the job_id "
+        "only if an explicit status check is needed."
+    ),
+}
 
 
 def _now() -> str:
@@ -278,17 +288,23 @@ class ConsolidationQueueService:
             "started_at": job.started_at,
             "finished_at": job.finished_at,
             "progress": dict(job.progress),
+            "next_action": NO_AUTO_POLLING_NEXT_ACTION,
+            "polling": dict(NO_AUTO_POLLING_CONTRACT),
         }
         if job.status == "running":
             payload["message"] = (
-                "Consolidation request accepted. This job is running for "
-                f"space '{job.space_id}'."
+                "Async consolidation job accepted and running for "
+                f"space '{job.space_id}'. Do not wait for completion by "
+                "default. Use bank_consolidation_status only for an explicit "
+                "status check."
             )
         elif job.status == "queued":
             payload["message"] = (
-                "Consolidation request accepted. Another consolidation is "
+                "Async consolidation job accepted. Another consolidation is "
                 f"running for '{job.space_id}'; this job is queued at "
-                f"position {payload['queue_position']}."
+                f"position {payload['queue_position']}. Do not wait for "
+                "completion by default. Use bank_consolidation_status only "
+                "for an explicit status check."
             )
         if job.result is not None:
             payload["result"] = job.result

--- a/src/live_mem/tools/bank.py
+++ b/src/live_mem/tools/bank.py
@@ -324,7 +324,10 @@ def register(mcp: FastMCP) -> int:
                    Si l'agent est différent → manage requis.
 
         Returns:
-            Accusé de réception du job (running/queued + job_id)
+            Accusé de réception async du job (running/queued + job_id),
+            incluant le contrat machine-readable demandant de rendre la main
+            sans attendre ni poller automatiquement. `bank_consolidation_status`
+            est réservé aux demandes explicites de statut.
         """
         from ..auth.context import (
             check_access,

--- a/tests/test_consolidation_queue.py
+++ b/tests/test_consolidation_queue.py
@@ -83,6 +83,13 @@ def _bank_tool(name: str):
     raise AssertionError(f"Tool {name} has no callable")
 
 
+def _assert_no_auto_polling_contract(payload: dict) -> None:
+    assert payload["next_action"] == "return_to_user_without_polling"
+    assert payload["polling"]["recommended"] is False
+    assert payload["polling"]["mode"] == "manual_only"
+    assert payload["polling"]["status_tool"] == "bank_consolidation_status"
+
+
 @pytest.fixture(autouse=True)
 def reset_queue():
     reset_consolidation_queue_for_tests()
@@ -103,6 +110,7 @@ async def test_enqueue_first_job_returns_running_and_processes_without_cooldown(
         assert result["status"] == "running"
         assert result["queue_position"] == 1
         assert result["guarantee"] == QUEUE_GUARANTEE
+        _assert_no_auto_polling_contract(result)
 
         await asyncio.wait_for(fake.started.wait(), timeout=1)
         fake.release.set()
@@ -142,6 +150,8 @@ async def test_same_space_second_request_is_queued_not_conflict_and_fifo():
         assert first["status"] == "running"
         assert second["status"] == "queued"
         assert second["queue_position"] == 2
+        _assert_no_auto_polling_contract(first)
+        _assert_no_auto_polling_contract(second)
 
         fake.release.set()
         await asyncio.sleep(0.05)


### PR DESCRIPTION
## Summary
- add a machine-readable no-auto-polling contract to bank_consolidate job payloads
- clarify running/queued human messages and docs: call once, do not watch/poll unless explicitly requested
- cover running and queued payload contracts in consolidation queue tests

## Tests
- .venv/bin/python -m pytest tests/test_consolidation_queue.py
- .venv/bin/python -m pytest