### PR TITLE
fix: ignore stale bank selection responses

### DIFF
--- a/src/live_mem/static/js/bank.js
+++ b/src/live_mem/static/js/bank.js
@@ -42,6 +42,8 @@ function renderBankTabs() {
 
 async function selectBank(filename) {
     app.currentBankFile = filename;
+    const requestedSpaceId = app.spaceId;
+    const requestedFilename = filename;
 
     // Mettre à jour les onglets actifs
     document.querySelectorAll('.bank-tab').forEach(t => {
@@ -52,7 +54,8 @@ async function selectBank(filename) {
     el.innerHTML = '<div class="empty-state">Loading…</div>';
 
     try {
-        const r = await apiLoadBankFile(app.spaceId, filename);
+        const r = await apiLoadBankFile(requestedSpaceId, requestedFilename);
+        if (app.spaceId !== requestedSpaceId || app.currentBankFile !== requestedFilename) return;
         if (r.status === 'ok' && r.content) {
             el.innerHTML = `<div class="md-content">${md(r.content)}</div>`;
         } else {
@@ -60,6 +63,7 @@ async function selectBank(filename) {
         }
     } catch (e) {
         if (e.message !== 'Unauthorized') {
+            if (app.spaceId !== requestedSpaceId || app.currentBankFile !== requestedFilename) return;
             el.innerHTML = `<div class="empty-state">❌ ${esc(e.message)}</div>`;
         }
     }

--- a/tests/test_live_ui_bank_race_guard.py
+++ b/tests/test_live_ui_bank_race_guard.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BANK_JS = ROOT / "src" / "live_mem" / "static" / "js" / "bank.js"
+
+
+def _select_bank_body() -> str:
+    source = BANK_JS.read_text()
+    match = re.search(r"async function selectBank\(filename\) \{(?P<body>.*?)\n\}", source, re.S)
+    assert match, "selectBank(filename) not found in bank.js"
+    return match.group("body")
+
+
+def test_select_bank_uses_captured_space_and_filename_for_load():
+    body = _select_bank_body()
+
+    assert "const requestedSpaceId = app.spaceId;" in body
+    assert "const requestedFilename = filename;" in body
+    assert "apiLoadBankFile(requestedSpaceId, requestedFilename)" in body
+
+
+def test_select_bank_drops_stale_responses_before_rendering():
+    body = _select_bank_body()
+    stale_guard = (
+        "app.spaceId !== requestedSpaceId "
+        "|| app.currentBankFile !== requestedFilename"
+    )
+
+    assert stale_guard in body
+    assert body.index(stale_guard) < body.index('el.innerHTML = `<div class="md-content">')
+    assert body.rindex(stale_guard) < body.rindex('el.innerHTML = `<div class="empty-state">❌')


### PR DESCRIPTION
## Summary
- capture the selected space and bank filename before loading bank content
- ignore stale success/error responses when the user switched space or bank meanwhile
- add a targeted static regression test for the /live bank selection race guard

Fixes #24.

## Tests
- uv run --no-sync python -m pytest tests/test_live_ui_bank_race_guard.py -q
- uv run --no-sync python -m pytest tests/ -q

Note: the exact `uv run pytest tests/ -q` command currently fails before pytest because `uv.lock` is not parseable by this uv version (missing package version at line 431).